### PR TITLE
1-series overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Ignore compiled lisp files
+*.FASL
+*.fasl
+*.lisp-temp
+*.dfsl
+*.pfsl
+*.d64fsl
+*.p64fsl
+*.lx64fsl
+*.lx32fsl
+*.dx64fsl
+*.dx32fsl
+*.fx64fsl
+*.fx32fsl
+*.sx64fsl
+*.sx32fsl
+*.wx64fsl
+*.wx32fsl

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017-2022, Atlas Engineer LLC.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.org
+++ b/README.org
@@ -31,9 +31,9 @@ The main types are:
 - Support keycode.
 - Validate keyspec at compile time.
 - ~define-key~ can set multiple bindings in a single call.
-- Support multiple scheme to make it easy to switch between, say, Emacs-style
+- Support multiple keyschemes to make it easy to switch between, say, Emacs-style
   and VI-style bindings.  This orthogonality to keymaps composes better than
-  having multiple keymaps: changing scheme applies to the entire program, which
+  having multiple keymaps: changing keyscheme applies to the entire program, which
   is easier than looping through all keymaps to change them.
 - Translate keyspecs as a fallback.  For instance if =shift-a= is unbound, check
   =A=.

--- a/README.org
+++ b/README.org
@@ -62,6 +62,14 @@ The main types are:
 NKeymaps was originally developed for keymap management in [[https://nyxt.atlas.engineer][Nyxt]], so the "N"
 may stand for it, or "New", or whatever poetic meaning you may find behind it!
 
+** Road-map
+
+- [ ] Lookup order (for instance parent-first or next-keymap-first) should be customizable.
+
+- [ ] For now =*translator*= is a global, but ideally it would be part of the
+  keyscheme and keymap.  But this would impact the lookup order, since
+  translations come after all the keymaps and their parents have been searched for.
+
 ** Change log
 
 *** 1.0.0

--- a/README.org
+++ b/README.org
@@ -57,6 +57,26 @@ The main types are:
 - Global or local bindings: it's up to the calling application to manage the
   locality of their keymaps.
 
+** Example
+
+#+begin_src lisp
+  (let* ((parent-keymap (nkeymaps:make-keymap "parent-keymap"))
+         (my-keymap (nkeymaps:make-keymap "my-keymap" parent-keymap)))
+    (nkeymaps:define-key parent-keymap
+      "C-c" 'copy
+      "C-v" 'paste)
+    (nkeymaps:define-key my-keymap
+      "C-x" 'cut)
+    (values
+     (nkeymaps:lookup-key "C-x" parent-keymap)
+     (nkeymaps:lookup-key "C-x" my-keymap)
+     (nkeymaps:lookup-key "C-c" my-keymap)))
+
+  ;; => NIL, CUT, COPY
+#+end_src
+
+See the [[file:package.lisp][package]] documentation for a usage guide and more examples.
+
 ** History
 
 NKeymaps was originally developed for keymap management in [[https://nyxt.atlas.engineer][Nyxt]], so the "N"

--- a/README.org
+++ b/README.org
@@ -61,3 +61,23 @@ The main types are:
 
 NKeymaps was originally developed for keymap management in [[https://nyxt.atlas.engineer][Nyxt]], so the "N"
 may stand for it, or "New", or whatever poetic meaning you may find behind it!
+
+** Change log
+
+*** 1.0.0
+
+- Renamed =scheme-name= to =keyscheme= and =scheme= to =keyscheme-map=.
+  It's more consistent and intuitive.  The previous naming was really confusing.
+- All warnings have now their own conditions, see the =nkeymaps/conditions= package.
+- =define-keyscheme-map= has a different syntax, it's now
+  #+begin_src lisp
+    (define-keyscheme-map "NAME-PREFIX" (:import OPTIONAL-KEYSCHEME-MAP-TO-IMPORT)
+      KEYSCHEME BINDINGS...)
+  #+end_src
+- The predefined =keyscheme=s are now accessible from the =nkeymaps= package.
+- New =default= =keyscheme= which is the new parent of other keyschemes
+  (including =cua=), instead of =cua=.
+- =*modifier-list*= is no longer exported.  Instead, both =keyscheme= and
+  =keymap= have a =modifiers= slot for the modifiers they accept.
+- Switched testing framework from =Prove= to =Lisp-Unit2=.
+- Removed the =cl-str= dependency.

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -1,7 +1,22 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(in-package :nkeymaps)
+(uiop:define-package nkeymaps/conditions
+  (:use #:common-lisp)
+  (:export
+   #:cycle
+   #:duplicate-modifiers
+   #:override-existing-binding
+   #:bad-modifier
+   #:make-key-required-arg
+   #:empty-keyspec
+   #:empty-value
+   #:empty-modifiers)
+  (:documentation "Package listing conditions."))
+(in-package :nkeymaps/conditions)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps/conditions))
 
 (define-condition cycle (warning)
   ((message :initarg :message :accessor message :initform "Cycle detect in keymap")
@@ -15,7 +30,7 @@ This is possible if a bound value is a keymap that occured before."))
   ((message :initarg :message :accessor message :initform "Duplicate modifiers")
    (modifiers :initarg :modifiers :accessor modifiers :initform (alex:required-argument 'modifiers)))
   (:report (lambda (c stream)
-             (format stream "~a: ~a" (message c) (mapcar #'modifier-string (modifiers c)))))
+             (format stream "~a: ~a" (message c) (modifiers c))))
   (:documentation "Warning raised when a keyspec contains multiple occurences of the same
 modifiers."))
 

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -3,6 +3,14 @@
 
 (in-package :nkeymaps)
 
+(define-condition cycle (warning)
+  ((message :initarg :message :accessor message :initform "Cycle detect in keymap")
+   (keymap :initarg :keymap :accessor keymap :initform (alex:required-argument 'keymap)))
+  (:report (lambda (c stream)
+             (format stream "~a ~a" (message c) (keymap c))))
+  (:documentation "Warning raised when keymap has cycles.
+This is possible if a bound value is a keymap that occured before."))
+
 (define-condition bad-modifier (error)
   ((message :initarg :message :accessor message :initform ""))
   (:report (lambda (c stream)

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -11,6 +11,24 @@
   (:documentation "Warning raised when keymap has cycles.
 This is possible if a bound value is a keymap that occured before."))
 
+(define-condition duplicate-modifiers (warning)
+  ((message :initarg :message :accessor message :initform "Duplicate modifiers")
+   (modifiers :initarg :modifiers :accessor modifiers :initform (alex:required-argument 'modifiers)))
+  (:report (lambda (c stream)
+             (format stream "~a: ~a" (message c) (mapcar #'modifier-string (modifiers c)))))
+  (:documentation "Warning raised when a keyspec contains multiple occurences of the same
+modifiers."))
+
+(define-condition override-existing-binding (warning)
+  ((message :initarg :message :accessor message :initform "Key was bound to")
+   (existing-binding-value
+    :initarg :existing-binding-value
+    :accessor existing-binding-value
+    :initform (alex:required-argument 'existing-binding-value)))
+  (:report (lambda (c stream)
+             (format stream "~a ~a" (message c) (existing-binding-value c))))
+  (:documentation "Warning raised overriding an existing binding."))
+
 (define-condition bad-modifier (error)
   ((message :initarg :message :accessor message :initform ""))
   (:report (lambda (c stream)

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -11,7 +11,8 @@
    #:make-key-required-arg
    #:empty-keyspec
    #:empty-value
-   #:empty-modifiers)
+   #:empty-modifiers
+   #:bad-keyspec)
   (:documentation "Package listing conditions."))
 (in-package :nkeymaps/conditions)
 
@@ -63,13 +64,27 @@ modifiers."))
              (format stream "~a" "Empty keyspec."))))
 
 (define-condition empty-value (error)
-  ()
+  ((keyspec
+    :initarg :keyspec
+    :accessor keyspec
+    :initform (alex:required-argument 'keyspec)))
   (:report (lambda (c stream)
-             (declare (ignore c))
-             (format stream "~a" "Empty key code or value."))))
+             (format stream "Empty key code or value in keyspec ~s" (keyspec c)))))
 
 (define-condition empty-modifiers (error)
-  ()
+  ((keyspec
+    :initarg :keyspec
+    :accessor keyspec
+    :initform (alex:required-argument 'keyspec)))
   (:report (lambda (c stream)
-             (declare (ignore c))
-             (format stream "~a" "Empty modifier(s)."))))
+             (format stream "Empty modifier(s) in keyspec ~s." (keyspec c)))))
+
+(define-condition bad-keyspec (warning)
+  ((message :initarg :message :accessor message :initform "Illegal keyspec")
+   (error-condition
+    :initarg :error-condition
+    :accessor error-condition
+    :initform (alex:required-argument 'error-condition)))
+  (:report (lambda (c stream)
+             (format stream "~a: ~a" (message c) (error-condition c))))
+  (:documentation "Warning raised when trying to derive a key from an illegal keyspec."))

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -559,7 +559,7 @@ Return NIL if no value is found.
 
 The successive keymaps from KEYMAP-OR-KEYMAPS (if a list) are looked up one
 after the other.
-If no binding is found, the direct parents are lookeup up in the same order.
+If no binding is found, the direct parents are looked up up in the same order.
 And so on if the binding is still not found."
   (let* ((keys (if (stringp keys-or-keyspecs)
                    (keyspecs->keys keys-or-keyspecs)

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -562,7 +562,7 @@ Return NIL if no value is found.
 
 The successive keymaps from KEYMAP-OR-KEYMAPS (if a list) are looked up one
 after the other.
-If no binding is found, the direct parents are looked up up in the same order.
+If no binding is found, the direct parents are looked up in the same order.
 And so on if the binding is still not found."
   (let* ((keys (if (stringp keys-or-keyspecs)
                    (keyspecs->keys keys-or-keyspecs)

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -98,9 +98,8 @@ specify a key-code binding."
                            (let* ((mods (mapcar #'modspec->modifier strings-or-modifiers))
                                   (no-dups-mods (delete-duplicates mods :test #'modifier=)))
                              (when (/= (length mods) (length no-dups-mods))
-                               (warn "Duplicate modifiers: ~a"
-                                     (mapcar #'modifier-string
-                                             (list-difference mods no-dups-mods))))
+                               (warn 'duplicate-modifiers
+                                     :modifiers (list-difference mods no-dups-mods)))
                              no-dups-mods))))))
 
 (declaim (ftype (function (&key (:code integer) (:value string)
@@ -424,7 +423,8 @@ Return KEYMAP."
       (progn
         (when (fset:@ (entries keymap) (first keys))
           ;; TODO: Notify caller properly?
-          (warn "Key was bound to ~a" (fset:@ (entries keymap) (first keys))))
+          (warn 'override-existing-binding
+                :existing-binding-value (fset:@ (entries keymap) (first keys))))
         (if bound-value
             (setf (fset:@ (entries keymap) (first keys)) bound-value)
             (setf (entries keymap) (fset:less (entries keymap) (first keys)))))

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -557,12 +557,12 @@ As a third value, return the possibly translated KEYS.
 
 Return NIL if no value is found.
 
-First keymap parents are looked up one after the other.
-Then keys translation are looked up one after the other.
-The same is done for the successive keymaps if KEYMAP-OR-KEYMAPS is a list of
-keymaps."
+The successive keymaps from KEYMAP-OR-KEYMAPS (if a list) are looked up one
+after the other.
+If no binding is found, the direct parents are lookeup up in the same order.
+And so on if the binding is still not found."
   (let* ((keys (if (stringp keys-or-keyspecs)
-                   (nkeymaps::keyspecs->keys keys-or-keyspecs)
+                   (keyspecs->keys keys-or-keyspecs)
                    keys-or-keyspecs))
          (matching-keymap nil)
          (matching-key nil)

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -99,7 +99,7 @@ specify a key-code binding."
                                   (no-dups-mods (delete-duplicates mods :test #'modifier=)))
                              (when (/= (length mods) (length no-dups-mods))
                                (warn 'duplicate-modifiers
-                                     :modifiers (list-difference mods no-dups-mods)))
+                                     :modifiers (mapcar #'modifier-string (list-difference mods no-dups-mods))))
                              no-dups-mods))))))
 
 (declaim (ftype (function (&key (:code integer) (:value string)

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -146,7 +146,7 @@ key values because `fset:equal?` folds case."
       :equal
       :unequal))
 
-(declaim (ftype (function (string &optional boolean) key) keyspec->key))
+(declaim (ftype (function (string &optional boolean) (or key null)) keyspec->key))
 (defun keyspec->key (string &optional error-p)
   "Parse STRING and return a new `key'.
 The specifier is expected to be in the form
@@ -162,7 +162,7 @@ Note that '-' or '#' as a last character is supported, e.g. 'control--' and
                             #'identity
                             (lambda (c)
                               (warn 'bad-keyspec :error-condition c)
-                              (return-from keyspec->key)))))
+                              (return-from keyspec->key nil)))))
     (when (string= string "")
       (error 'empty-keyspec))
     (let* ((last-nonval-hyphen (or (position #\- string :from-end t

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -1,7 +1,7 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(in-package :nkeymaps)
+(in-package :nkeymaps/core)
 
 ;; TODO: Add timeout support, e.g. "jk" in less than 0.1s could be ESC in VI-style.
 

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -479,7 +479,7 @@ Return (keymap1 keymap2 k1a k1b k2a k1ap)."
             (keymap-tree->list
              (delete-if (lambda (keymap)
                           (when (find keymap visited)
-                            (warn "Cycle detected in keymap ~a" keymap)
+                            (warn 'cycle :keymap keymap)
                             t))
                         (alex:mappend #'parents keymaps))
              (append keymaps visited)))))
@@ -497,7 +497,7 @@ As a second value, return the matching keymap."
          (result
           (some (lambda (keymap)
                   (if (find keymap visited)
-                      (warn "Cycle detected in keymap ~a" keymap)
+                      (warn 'cycle :keymap keymap)
                       (let ((hit (lookup-keys-in-keymap
                                   keymap
                                   keys
@@ -578,7 +578,7 @@ See `key->keyspec' for the details."
              (if (keymap-p sym)
                  (cond
                    ((find sym visited)
-                    (warn "Cycle detected in keymap ~a" keymap)
+                    (warn 'cycle :keymap keymap)
                     result)
                    (t
                     (fset:map-union result
@@ -611,7 +611,7 @@ Keymaps are ordered by precedence, highest precedence comes first."
                ((null keymap)
                 '())
                ((find keymap visited)
-                (warn "Cycle detected in parent keymap ~a" keymap)
+                (warn 'cycle  :keymap keymap)
                 '())
                (t
                 (cons keymap
@@ -665,7 +665,7 @@ Comparison against BINDING is done with TEST."
                    ((funcall test binding sym)
                     (push (list key) result))
                    ((and (keymap-p sym) (find sym visited))
-                    (warn "Cycle detected in keymap ~a" keymap))
+                    (warn 'cycle :keymap keymap))
                    ((keymap-p sym)
                     (dolist (hit (scan-keymap sym (cons keymap visited)))
                       (push (cons key hit) result)))))

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -350,7 +350,7 @@ Parents are ordered by priority, the first parent has highest priority.")))
 ;; types that use `satisfies' for non-top-level symbols.
 ;; We can verify this with:
 ;;
-;;   (compile 'foo (lambda () (nkeymaps::define-key keymap "C-x C-f" 'open-file)))
+;;   (compile nil (lambda () (nkeymaps::define-key keymap "C-x C-f" 'open-file)))
 (defmacro define-key (keymap keyspecs bound-value &rest more-keyspecs-value-pairs)
   "Bind KEYS to BOUND-VALUE in KEYMAP.
 Return KEYMAP.

--- a/keymap.lisp
+++ b/keymap.lisp
@@ -521,7 +521,7 @@ For now the status is not encoded in the keyspec, this may change in the future.
                                          #'modifier-shortcut
                                          #'modifier-string))))
     (the (values keyspecs-type &optional)
-         (uiop:strcat (if (str:empty? modifiers) "" (uiop:strcat modifiers "-"))
+         (uiop:strcat (if (uiop:emptyp modifiers) "" (uiop:strcat modifiers "-"))
                       value))))
 
 (declaim (ftype (function ((list-of key)) keyspecs-type) keys->keyspecs))

--- a/keyscheme-map.lisp
+++ b/keyscheme-map.lisp
@@ -1,7 +1,7 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(in-package :nkeymaps)
+(in-package :nkeymaps/core)
 
 (defclass keyscheme ()
   ((name :initarg :name

--- a/keyscheme-map.lisp
+++ b/keyscheme-map.lisp
@@ -1,7 +1,6 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-;; TODO: Rename to keyscheme-map.lisp.
 (in-package :nkeymaps)
 
 (defclass keyscheme ()

--- a/keyschemes.lisp
+++ b/keyschemes.lisp
@@ -1,8 +1,6 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-;; TODO: Rename to keyschemes.lisp.
-
 (in-package :nkeymaps/keyscheme)
 
 (defvar cua (make-keyscheme "cua"))

--- a/keyschemes.lisp
+++ b/keyschemes.lisp
@@ -3,7 +3,8 @@
 
 (in-package :nkeymaps/keyscheme)
 
-(defvar cua (make-keyscheme "cua"))
-(defvar emacs (make-keyscheme "emacs" cua))
-(defvar vi-normal (make-keyscheme "vi-normal" cua emacs))
-(defvar vi-insert (make-keyscheme "vi-insert" cua))
+(defvar default (make-keyscheme "default"))
+(defvar cua (make-keyscheme "cua" default))
+(defvar emacs (make-keyscheme "emacs" default))
+(defvar vi-normal (make-keyscheme "vi-normal" default))
+(defvar vi-insert (make-keyscheme "vi-insert"))

--- a/modifiers.lisp
+++ b/modifiers.lisp
@@ -1,0 +1,10 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nkeymaps/modifier)
+
+(defparameter +control+ (nkeymaps:define-modifier :string "control" :shortcut "C"))
+(defparameter +meta+ (define-modifier :string "meta" :shortcut "M"))
+(defparameter +shift+ (define-modifier :string "shift" :shortcut "s"))
+(defparameter +super+ (define-modifier :string "super" :shortcut "S"))
+(defparameter +hyper+ (define-modifier :string "hyper" :shortcut "H"))

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -2,7 +2,7 @@
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
 (defsystem "nkeymaps"
-  :version "0.1.1"
+  :version "1"
   :description "General-purpose keymap management à-la Emacs."
   :author "Atlas Engineer LLC"
   :homepage "https://github.com/atlas-engineer/nkeymaps"

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -7,7 +7,7 @@
   :author "Atlas Engineer LLC"
   :homepage "https://github.com/atlas-engineer/nkeymaps"
   :license "BSD 3-Clause"
-  :depends-on (alexandria fset trivial-package-local-nicknames)
+  :depends-on (alexandria fset trivial-package-local-nicknames uiop)
   :serial t
   :components ((:file "types")
                (:file "conditions")

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -7,7 +7,7 @@
   :author "Atlas Engineer LLC"
   :homepage "https://github.com/atlas-engineer/nkeymaps"
   :license "BSD 3-Clause"
-  :depends-on (alexandria fset str trivial-package-local-nicknames)
+  :depends-on (alexandria fset trivial-package-local-nicknames)
   :serial t
   :components ((:file "types")
                (:file "package")

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -9,8 +9,8 @@
   :license "BSD 3-Clause"
   :depends-on (alexandria fset str trivial-package-local-nicknames)
   :serial t
-  :components ((:file "package")
-               (:file "types")
+  :components ((:file "types")
+               (:file "package")
                (:file "conditions")
                (:file "keymap")
                (:file "scheme")

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -10,8 +10,8 @@
   :depends-on (alexandria fset trivial-package-local-nicknames)
   :serial t
   :components ((:file "types")
-               (:file "package")
                (:file "conditions")
+               (:file "package")
                (:file "keymap")
                (:file "keyscheme-map")
                (:file "keyschemes"))

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -13,6 +13,8 @@
                (:file "conditions")
                (:file "package")
                (:file "keymap")
+               (:file "modifiers")
+               (:file "translators")
                (:file "keyscheme-map")
                (:file "keyschemes"))
   :in-order-to ((test-op (test-op "nkeymaps/tests"))))

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -18,7 +18,12 @@
   :in-order-to ((test-op (test-op "nkeymaps/tests"))))
 
 (defsystem "nkeymaps/tests"
-  :depends-on (alexandria fset nkeymaps prove)
-  :components ((:file "test-package"))
+  :depends-on (alexandria fset nkeymaps lisp-unit2)
+  :pathname "tests/"
+  :serial t
+  :components ((:file "package")
+               (:file "tests")
+               (:file "keyscheme-tests"))
   :perform (test-op (op c)
-                    (symbol-call :prove :run (system-relative-pathname c "tests/"))))
+                    (symbol-call :lisp-unit2 :run-tests :package :nkeymaps/tests
+                                 :run-contexts (find-symbol "WITH-SUMMARY-CONTEXT" :lisp-unit2))))

--- a/nkeymaps.asd
+++ b/nkeymaps.asd
@@ -13,8 +13,8 @@
                (:file "package")
                (:file "conditions")
                (:file "keymap")
-               (:file "scheme")
-               (:file "scheme-names"))
+               (:file "keyscheme-map")
+               (:file "keyschemes"))
   :in-order-to ((test-op (test-op "nkeymaps/tests"))))
 
 (defsystem "nkeymaps/tests"

--- a/package.lisp
+++ b/package.lisp
@@ -6,6 +6,10 @@
         #:nkeymaps/types
         #:nkeymaps/conditions)
   (:import-from #:fset)
+  (:import-from #:alexandria
+                #:compose
+                #:curry
+                #:rcurry)
   (:export
    #:define-modifier
    #:modifier=

--- a/package.lisp
+++ b/package.lisp
@@ -52,6 +52,7 @@
    #:compose
 
    ;; conditions
+   #:cycle
    #:bad-modifier
    #:make-key-required-arg
    #:empty-keyspec

--- a/package.lisp
+++ b/package.lisp
@@ -103,9 +103,9 @@ See `nkeymaps:*translator*'."))
    #:nkeymaps/translator)
   (:documentation "
 The workflow goes as follows:
-- Make a keymap with `make-keymap'.
-- Define a binding on it with `define-key'.
-- Lookup this binding with `lookup-key'.
+- Make a keymap with `nkeymaps:make-keymap'.
+- Define a binding on it with `nkeymaps:define-key'.
+- Lookup this binding with `nkeymaps:lookup-key'.
 
 Example:
 
@@ -122,7 +122,9 @@ Example:
    (nkeymaps:lookup-key \"C-c\" my-keymap)))
 ;; => NIL, CUT, COPY
 
-Another workflow is to use `keyscheme's which allow to compose different binding styles.
+Another workflow is to use `nkeymaps:keyscheme's which allow to compose
+different binding styles.
+
 Example:
 
 \(nkeymaps:define-keyscheme-map \"test\" ()
@@ -130,29 +132,33 @@ Example:
                                               \"C-v\" paste)
                                nkeymaps:emacs '(\"C-x\" cut))
 
-The default keyschemes can be listed from the `nkeymaps/keyscheme' package
+The default keyschemes can be listed from the `nkeymaps/keyscheme:' package
 exported symbols.
 
-New keyschemes can be created with `make-keyscheme'.
+New keyschemes can be created with `nkeymaps:make-keyscheme'.
 
-Keys can be created with `make-key', which gives you more fine-tuning compared
-to the \"keyspecs\" above:
+Keys can be created with `nkeymaps:make-key', which gives you more fine-tuning
+compared to the \"keyspecs\" above:
 
   (nkeymaps:make-key :code 38 :value \"a\" :modifiers '(\"C\"))
 
-The reverse-action of `lookup-key' is `binding-keys'.
+You can also specify key codes from the keyspec directly.  For instance,
+\"C-#10\" corresponds to keycode 10 with the `nkeymaps:+control+'.
 
-Keymaps can be composed with `compose'.
 
-New modifiers can be defined with `define-modifier'.
+The reverse-action of `nkeymaps:lookup-key' is `nkeymaps:binding-keys'.
+
+Keymaps can be composed with `nkeymaps:compose'.
+
+New modifiers can be defined with `nkeymaps:define-modifier'.
 
    (nkeymaps:define-modifier :string \"duper\" :shortcut \"D\")
 
 Some globals can be tweaked to customize the library to your needs:
 
-- `*translator*': The function to infer the right binding when
+- `nkeymaps:*translator*': The function to infer the right binding when
   the exact binding hits nothing.
-- `*print-shortcuts*': Print modifiers using their short form instead of the
+- `nkeymaps:*print-shortcut*': Print modifiers using their short form instead of the
   full name, e.g. \"C\" instead of \"control\"."))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)

--- a/package.lisp
+++ b/package.lisp
@@ -1,13 +1,10 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-;; TODO: Reexport nkeymaps/keyscheme.
-(uiop:define-package nkeymaps
+(uiop:define-package nkeymaps/core
   (:use #:common-lisp
         #:nkeymaps/types
         #:nkeymaps/conditions)
-  (:reexport #:nkeymaps/types
-             #:nkeymaps/conditions)
   (:import-from #:fset)
   (:export
    #:modifier=
@@ -63,6 +60,26 @@
    #:define-keyscheme-map
    #:get-keymap
    #:make-keyscheme-map)
+  (:documentation "See the `nkeymaps' package documentation."))
+
+(uiop:define-package nkeymaps/keyscheme
+  (:use #:common-lisp)
+  (:import-from #:nkeymaps/core #:make-keyscheme)
+  (:export
+   #:cua
+   #:emacs
+   #:vi-normal
+   #:vi-insert)
+  (:documentation "Package holding the list of well-known keyschemes.
+We use a dedicated package so that keyschemes can easily be listed and completed."))
+
+(uiop:define-package nkeymaps
+  (:use #:common-lisp)
+  (:use-reexport
+   #:nkeymaps/types
+   #:nkeymaps/conditions
+   #:nkeymaps/core
+   #:nkeymaps/keyscheme)
   (:documentation "
 The workflow goes as follows:
 - Make a keymap with `make-keymap'.
@@ -78,17 +95,6 @@ Some globals can be tweaked to customize the library to your needs:
   full name, e.g. \"C\" instead of \"control\".
 - `*default-bound-type*': The allowed type for bound values; default to T (everything)."))
 
-(uiop:define-package nkeymaps/keyscheme
-  (:use #:common-lisp)
-  (:import-from #:nkeymaps #:make-keyscheme)
-  (:export
-   #:cua
-   #:emacs
-   #:vi-normal
-   #:vi-insert)
-  (:documentation "Package holding the list of well-known keyschemes.
-We use a dedicated package so that keyschemes can easily be listed and completed."))
-
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps)
-  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps/keyscheme))
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps/core)
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps))

--- a/package.lisp
+++ b/package.lisp
@@ -89,6 +89,47 @@ The workflow goes as follows:
 - Define a binding on it with `define-key'.
 - Lookup this binding with `lookup-key'.
 
+Example:
+
+\(let* ((parent-keymap (nkeymaps:make-keymap \"parent-keymap\"))
+       (my-keymap (nkeymaps:make-keymap \"my-keymap\" parent-keymap)))
+  (nkeymaps:define-key parent-keymap
+    \"C-c\" 'copy
+    \"C-v\" 'paste)
+  (nkeymaps:define-key my-keymap
+    \"C-x\" 'cut)
+  (values
+   (nkeymaps:lookup-key \"C-x\" parent-keymap)
+   (nkeymaps:lookup-key \"C-x\" my-keymap)
+   (nkeymaps:lookup-key \"C-c\" my-keymap)))
+;; => NIL, CUT, COPY
+
+Another workflow is to use `keyscheme's which allow to compose different binding styles.
+Example:
+
+\(nkeymaps:define-keyscheme-map \"test\" ()
+                               nkeymaps:cua '(\"C-c\" copy
+                                              \"C-v\" paste)
+                               nkeymaps:emacs '(\"C-x\" cut))
+
+The default keyschemes can be listed from the `nkeymaps/keyscheme' package
+exported symbols.
+
+New keyschemes can be created with `make-keyscheme'.
+
+Keys can be created with `make-key', which gives you more fine-tuning compared
+to the \"keyspecs\" above:
+
+  (nkeymaps:make-key :code 38 :value \"a\" :modifiers '(\"C\"))
+
+The reverse-action of `lookup-key' is `binding-keys'.
+
+Keymaps can be composed with `compose'.
+
+New modifiers can be defined with `define-modifier'.
+
+   (nkeymaps:define-modifier :string \"duper\" :shortcut \"D\")
+
 Some globals can be tweaked to customize the library to your needs:
 
 - `*translator*': The function to infer the right binding when

--- a/package.lisp
+++ b/package.lisp
@@ -7,6 +7,7 @@
         #:nkeymaps/conditions)
   (:import-from #:fset)
   (:export
+   #:define-modifier
    #:modifier=
    #:+control+
    #:+meta+
@@ -14,7 +15,7 @@
    #:+super+
    #:+hyper+
 
-   #:*modifier-list*
+
 
    #:key
    #:make-key
@@ -33,6 +34,7 @@
    #:parents
    #:name
    #:bound-type
+   #:modifiers
 
    #:translate-remove-shift-toggle-case
    #:translate-remove-shift

--- a/package.lisp
+++ b/package.lisp
@@ -3,7 +3,7 @@
 
 ;; TODO: Reexport nkeymaps/keyscheme.
 (uiop:define-package nkeymaps
-  (:use #:common-lisp)
+  (:use #:common-lisp #:nkeymaps/types)
   (:import-from #:fset)
   (:import-from #:str)
   (:export

--- a/package.lisp
+++ b/package.lisp
@@ -1,6 +1,7 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
+;; TODO: Reexport nkeymaps/keyscheme.
 (uiop:define-package nkeymaps
   (:use #:common-lisp)
   (:import-from #:fset)
@@ -58,14 +59,14 @@
    #:empty-modifiers
 
    ;; scheme
-   #:scheme-name
-   #:make-scheme-name
-   #:scheme-name-p
-   #:scheme
-   #:scheme-p
-   #:define-scheme
+   #:keyscheme
+   #:make-keyscheme
+   #:keyscheme-p
+   #:keyscheme-map
+   #:keyscheme-map-p
+   #:define-keyscheme-map
    #:get-keymap
-   #:make-scheme)
+   #:make-keyscheme-map)
   (:documentation "
 The workflow goes as follows:
 - Make a keymap with `make-keymap'.
@@ -81,17 +82,17 @@ Some globals can be tweaked to customize the library to your needs:
   full name, e.g. \"C\" instead of \"control\".
 - `*default-bound-type*': The allowed type for bound values; default to T (everything)."))
 
-(uiop:define-package nkeymaps/scheme
+(uiop:define-package nkeymaps/keyscheme
   (:use #:common-lisp)
-  (:import-from #:nkeymaps #:make-scheme-name)
+  (:import-from #:nkeymaps #:make-keyscheme)
   (:export
    #:cua
    #:emacs
    #:vi-normal
    #:vi-insert)
-  (:documentation "Package holding the list of well-known scheme names.
-We use a dedicated package so that scheme names can easily be listed and completed."))
+  (:documentation "Package holding the list of well-known keyschemes.
+We use a dedicated package so that keyschemes can easily be listed and completed."))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps)
-  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps/scheme))
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps/keyscheme))

--- a/package.lisp
+++ b/package.lisp
@@ -91,12 +91,10 @@ The workflow goes as follows:
 
 Some globals can be tweaked to customize the library to your needs:
 
-- `*modifier-list*': List of known keyboard modifiers like `+control+'.
 - `*translator*': The function to infer the right binding when
   the exact binding hits nothing.
 - `*print-shortcuts*': Print modifiers using their short form instead of the
-  full name, e.g. \"C\" instead of \"control\".
-- `*default-bound-type*': The allowed type for bound values; default to T (everything)."))
+  full name, e.g. \"C\" instead of \"control\"."))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps/core)

--- a/package.lisp
+++ b/package.lisp
@@ -7,7 +7,6 @@
         #:nkeymaps/conditions)
   (:import-from #:fset)
   (:import-from #:alexandria
-                #:compose
                 #:curry
                 #:rcurry)
   (:export

--- a/package.lisp
+++ b/package.lisp
@@ -69,6 +69,7 @@
   (:import-from #:nkeymaps/core #:make-keyscheme)
   (:export
    #:cua
+   #:default
    #:emacs
    #:vi-normal
    #:vi-insert)

--- a/package.lisp
+++ b/package.lisp
@@ -5,7 +5,6 @@
 (uiop:define-package nkeymaps
   (:use #:common-lisp #:nkeymaps/types)
   (:import-from #:fset)
-  (:import-from #:str)
   (:export
    #:modifier=
    #:+control+

--- a/package.lisp
+++ b/package.lisp
@@ -132,7 +132,7 @@ Example:
                                               \"C-v\" paste)
                                nkeymaps:emacs '(\"C-x\" cut))
 
-The default keyschemes can be listed from the `nkeymaps/keyscheme:' package
+The default keyschemes can be listed from the `nkeymaps/keyscheme' package
 exported symbols.
 
 New keyschemes can be created with `nkeymaps:make-keyscheme'.

--- a/package.lisp
+++ b/package.lisp
@@ -3,7 +3,11 @@
 
 ;; TODO: Reexport nkeymaps/keyscheme.
 (uiop:define-package nkeymaps
-  (:use #:common-lisp #:nkeymaps/types)
+  (:use #:common-lisp
+        #:nkeymaps/types
+        #:nkeymaps/conditions)
+  (:reexport #:nkeymaps/types
+             #:nkeymaps/conditions)
   (:import-from #:fset)
   (:export
    #:modifier=
@@ -49,16 +53,6 @@
    #:binding-keys
 
    #:compose
-
-   ;; conditions
-   #:cycle
-   #:duplicate-modifiers
-   #:override-existing-binding
-   #:bad-modifier
-   #:make-key-required-arg
-   #:empty-keyspec
-   #:empty-value
-   #:empty-modifiers
 
    ;; scheme
    #:keyscheme

--- a/package.lisp
+++ b/package.lisp
@@ -9,13 +9,6 @@
   (:export
    #:define-modifier
    #:modifier=
-   #:+control+
-   #:+meta+
-   #:+shift+
-   #:+super+
-   #:+hyper+
-
-
 
    #:key
    #:make-key
@@ -36,12 +29,6 @@
    #:bound-type
    #:modifiers
 
-   #:translate-remove-shift-toggle-case
-   #:translate-remove-shift
-   #:translate-remove-but-first-control
-   #:translate-remove-shift-but-first-control
-   #:translate-remove-shift-but-first-control-toggle-case
-   #:translate-shifted-control-combinations
    #:*translator*
 
    #:*print-shortcut*
@@ -76,13 +63,41 @@
   (:documentation "Package holding the list of well-known keyschemes.
 We use a dedicated package so that keyschemes can easily be listed and completed."))
 
+(uiop:define-package nkeymaps/modifier
+  (:use #:common-lisp)
+  (:import-from #:nkeymaps/core #:define-modifier)
+  (:export
+   #:+control+
+   #:+meta+
+   #:+shift+
+   #:+super+
+   #:+hyper+)
+  (:documentation "Package holding the list of predefined modifiers.
+We use a dedicated package so that modifiers can easily be listed and completed.
+See `nkeymaps:define-modifier'."))
+
+(uiop:define-package nkeymaps/translator
+  (:use #:common-lisp #:nkeymaps/core #:nkeymaps/modifier)
+  (:export
+   #:translate-remove-shift-toggle-case
+   #:translate-remove-shift
+   #:translate-remove-but-first-control
+   #:translate-remove-shift-but-first-control
+   #:translate-remove-shift-but-first-control-toggle-case
+   #:translate-shifted-control-combinations)
+  (:documentation "Package holding the list of predefined translators.
+We use a dedicated package so that modifiers can easily be listed and completed.
+See `nkeymaps:*translator*'."))
+
 (uiop:define-package nkeymaps
   (:use #:common-lisp)
   (:use-reexport
    #:nkeymaps/types
    #:nkeymaps/conditions
    #:nkeymaps/core
-   #:nkeymaps/keyscheme)
+   #:nkeymaps/keyscheme
+   #:nkeymaps/modifier
+   #:nkeymaps/translator)
   (:documentation "
 The workflow goes as follows:
 - Make a keymap with `make-keymap'.

--- a/package.lisp
+++ b/package.lisp
@@ -52,6 +52,8 @@
 
    ;; conditions
    #:cycle
+   #:duplicate-modifiers
+   #:override-existing-binding
    #:bad-modifier
    #:make-key-required-arg
    #:empty-keyspec

--- a/scheme-names.lisp
+++ b/scheme-names.lisp
@@ -1,9 +1,11 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(in-package :nkeymaps/scheme)
+;; TODO: Rename to keyschemes.lisp.
 
-(defvar cua (make-scheme-name "cua"))
-(defvar emacs (make-scheme-name "emacs" cua))
-(defvar vi-normal (make-scheme-name "vi-normal" cua emacs))
-(defvar vi-insert (make-scheme-name "vi-insert" cua))
+(in-package :nkeymaps/keyscheme)
+
+(defvar cua (make-keyscheme "cua"))
+(defvar emacs (make-keyscheme "emacs" cua))
+(defvar vi-normal (make-keyscheme "vi-normal" cua emacs))
+(defvar vi-insert (make-keyscheme "vi-insert" cua))

--- a/scheme.lisp
+++ b/scheme.lisp
@@ -13,7 +13,7 @@
    (parents :initarg :parents
             :accessor parents
             :initform '()
-            :type list-of-scheme-names
+            :type (list-of keyscheme)
             :documentation "The list of parents.  When a scheme is defined, the
 keymap parents are automatically set to the keymaps corresponding to the given
 keyschemes.  See `define-keyscheme-map'.")

--- a/scheme.lisp
+++ b/scheme.lisp
@@ -1,9 +1,10 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
+;; TODO: Rename to keyscheme-map.lisp.
 (in-package :nkeymaps)
 
-(defclass scheme-name ()
+(defclass keyscheme ()
   ((name :initarg :name
          :accessor name
          :type string
@@ -15,85 +16,88 @@
             :type list-of-scheme-names
             :documentation "The list of parents.  When a scheme is defined, the
 keymap parents are automatically set to the keymaps corresponding to the given
-schemes.  See `define-scheme'.")
+keyschemes.  See `define-keyscheme-map'.")
    (bound-type :accessor bound-type
                :initarg :bound-type
                :initform *default-bound-type*
                :documentation
                "Type of the bound-value.
-The type is enforced in `define-scheme' at macro-expansion time.
+The type is enforced in `define-keyscheme-map' at macro-expansion time.
 Type should allow `keymap's, so it should probably be in the form
 \(or keymap NON-KEYMAP-BOUND-TYPE).")))
 
-(defmethod print-object ((scheme-name scheme-name) stream)
-  (print-unreadable-object (scheme-name stream :type t :identity t)
-    (format stream "~a" (name scheme-name))))
+(defmethod print-object ((object keyscheme) stream)
+  (print-unreadable-object (object stream :type t :identity t)
+    (format stream "~a" (name object))))
 
-(declaim (ftype (function (string &rest scheme-name) (values scheme-name &optional))
-                make-scheme-name))
-(defun make-scheme-name (name &rest parents)
-  "Return a new `scheme-name' object.
+(declaim (ftype (function (string &rest keyscheme) keyscheme)
+                make-keyscheme))
+(defun make-keyscheme (name &rest parents)
+  "Return a new `keyscheme' object.
 The scheme name inherits from the optional PARENTS, ordered by priority.
 
 Example:
 
-  (defvar emacs (make-scheme-name \"emacs\" cua))
+  (defvar emacs (make-keyscheme \"emacs\" cua))
 
 In the above, we define a new scheme name called `emacs` which inherits from the
-existing name `cua`."
-  (the (values scheme-name &optional)
-       (make-instance 'scheme-name
+existing keyscheme `cua`."
+  (the (values keyscheme &optional)
+       (make-instance 'keyscheme
                       :name name
                       :parents parents)))
 
-(defun scheme-name-p (name)
-  (typep name 'scheme-name))
+(defun keyscheme-p (name)
+  (typep name 'keyscheme))
 
 (declaim (ftype (function (hash-table) boolean) scheme-p))
-(defun scheme-p (scheme)
-  (loop :for name :being :the hash-keys :in scheme :using (:hash-value keymap)
-        :always (and (scheme-name-p name)
+(defun keyscheme-map-p (keyscheme-map)
+  (loop :for name :being :the hash-keys :in keyscheme-map :using (:hash-value keymap)
+        :always (and (keyscheme-p name)
                      (keymap-p keymap))))
 
-(deftype scheme ()
+(deftype keyscheme-map ()
+  "A `hash-table' mapping `keyscheme's to `keymap's."
   `(and hash-table
-        (satisfies scheme-p)))
+        (satisfies keyscheme-map-p)))
 
-(defun copy-scheme (scheme)
-  (let ((new-scheme (make-hash-table :test #'equal)))
-    (maphash (lambda (scheme-name keymap)
-               (setf (gethash scheme-name new-scheme)
+(defun copy-keyscheme-map (keyscheme-map)
+  (let ((new-keyscheme-map (make-hash-table :test #'equal)))
+    (maphash (lambda (keyscheme keymap)
+               (setf (gethash keyscheme new-keyscheme-map)
                      (copy-keymap keymap)))
-             scheme)
-    new-scheme))
+             keyscheme-map)
+    new-keyscheme-map))
 
-(declaim (ftype (function (string (or null scheme) scheme-name list &rest (or scheme-name list)) scheme) define-scheme*))
-(defun define-scheme* (name-prefix imported-scheme name bindings &rest more-name+bindings-pairs)
-  "Define scheme.
-See `define-scheme' for the user-facing function."
-  (let ((name+bindings-pairs (append (list name bindings) more-name+bindings-pairs))
-        (scheme (if imported-scheme
-                    (copy-scheme imported-scheme)
-                    (make-hash-table :test #'equal))))
-    (unless imported-scheme
-      (loop :for (name nil . nil) :on name+bindings-pairs :by #'cddr
-            :do (setf (gethash name scheme)
-                      (let ((new-keymap (make-keymap (format nil "~a-~a-map" name-prefix (name name)))))
-                        (setf (bound-type new-keymap) (bound-type name))
+(declaim (ftype (function (string (or null keyscheme-map) keyscheme list &rest (or keyscheme list))
+                          keyscheme-map)
+                define-scheme*))
+(defun define-keyscheme-map* (name-prefix imported-keyscheme-map keyscheme bindings &rest more-keyschemes+bindings-pairs)
+  "Define `keyscheme-map'.
+See `define-keyscheme-map' for the user-facing function."
+  (let ((name+bindings-pairs (append (list keyscheme bindings) more-keyschemes+bindings-pairs))
+        (keyscheme-map (if imported-keyscheme-map
+                           (copy-keyscheme-map imported-keyscheme-map)
+                           (make-hash-table :test #'equal))))
+    (unless imported-keyscheme-map
+      (loop :for (keyscheme nil . nil) :on name+bindings-pairs :by #'cddr
+            :do (setf (gethash keyscheme keyscheme-map)
+                      (let ((new-keymap (make-keymap (format nil "~a-~a-map" name-prefix (name keyscheme)))))
+                        (setf (bound-type new-keymap) (bound-type keyscheme))
                         new-keymap))))
     ;; Set parents now that all keymaps exist.
-    (maphash (lambda (name keymap)
+    (maphash (lambda (keyscheme keymap)
                (setf (parents keymap)
                      (delete nil
-                             (mapcar (lambda (parent-name) (gethash parent-name scheme))
-                                     (parents name)))))
-             scheme)
+                             (mapcar (lambda (parent-keyscheme) (gethash parent-keyscheme keyscheme-map))
+                                     (parents keyscheme)))))
+             keyscheme-map)
     ;; Set bindings.
-    (loop :for (name bindings . nil) :on name+bindings-pairs :by #'cddr
-          :for keymap = (gethash name scheme)
+    (loop :for (keyscheme bindings . nil) :on name+bindings-pairs :by #'cddr
+          :for keymap = (gethash keyscheme keyscheme-map)
           :do (loop :for (keyspecs bound-value . nil) :on bindings :by #'cddr
                     :do (define-key* keymap keyspecs bound-value))) ; TODO: Can we use define-key?
-    scheme))
+    keyscheme-map))
 
 (defun check-plist (plist &rest keys)
   "Raise error if PLIST has keys not in KEYS."
@@ -112,73 +116,79 @@ See `define-scheme' for the user-facing function."
        (eq (first arg) 'quote)
        (= 2 (length arg))))
 
-(defmacro define-scheme (scheme-specifier name bindings &rest more-name+bindings-pairs)
-  "Return a scheme, a hash table with scheme NAMEs as key and their BINDINGS as value.
-SCHEME-SPECIFIER is either a string or a plist in the form
+;; TODO: Replace with compiler-macro.  Then test type errors.
+;; TODO: Replace keyscheme-specifier with name followed by options.
+(defmacro define-keyscheme-map (keyscheme-specifier keyscheme bindings &rest more-keyscheme+bindings-pairs)
+  "Return a keyscheme-map, a hash table with `keyscheme's as key and `keymap's
+holding BINDINGS as value.
+
+KEYSCHEME-SPECIFIER is either a string or a plist in the form
 
   (:name-prefix NAME-PREFIX :import IMPORTED-SCHEME)
 
-The keymap names are prefixed with NAME-PREFIX or SCHEME-SPECIFIER (if a string)
-and suffixed with \"-map\".
+The keymap names are prefixed with NAME-PREFIX or KEYSCHEME-SPECIFIER (if a
+string) and suffixed with \"-map\".
 
 This is a macro like `define-key' so that it can type-check the BINDINGS
 keyspecs at compile-time.
 
 Example:
 
-  (define-scheme \"my-mode\"
-    scheme:cua (list
-                \"C-c\" 'copy
-                \"C-v\" 'paste)
+  (define-keyscheme-map \"my-mode\"
+    nkeymaps/keyscheme:cua (list
+                   \"C-c\" 'copy
+                   \"C-v\" 'paste)
 
-    scheme:emacs '(\"M-w\" copy
-                   \"M-y\" paste))
+    nkeymaps/keyscheme:emacs '(\"M-w\" copy
+                      \"M-y\" paste))
 
-`scheme:cua' and `scheme:emacs' are pre-defined scheme names.  To define a new
-scheme name, see `make-scheme-name'.
+`nkeymaps/keyscheme:cua' and `nkeymaps/keyscheme:emacs' are pre-defined keyschemes.  To define a new
+keyscheme, see `make-keyscheme'.
 
-`scheme:cua' is a parent of `scheme:emacs'; thus, in the above example, the Emacs keymap
-will have the CUA keymap as parent.
-The scheme keymaps are named \"my-mode-cua-map\" and \"my-mode-emacs-map\"."
-  (let ((name+bindings-pairs (append (list name bindings) more-name+bindings-pairs))
-        (name-prefix (if (stringp scheme-specifier)
-                         scheme-specifier
-                         (getf scheme-specifier :name-prefix)))
-        (imported-scheme (unless (stringp scheme-specifier)
-                           (getf scheme-specifier :import))))
-    (unless (stringp scheme-specifier)
-      (check-plist scheme-specifier :name-prefix :import))
-    (loop :for (name quoted-bindings . nil) :on name+bindings-pairs :by #'cddr
+`nkeymaps/keyscheme:cua' is a parent of `nkeymaps/keyscheme:emacs'; thus, in the above example,
+the Emacs keymap will have the CUA keymap as parent.
+The keyscheme-map keymaps are named \"my-mode-cua-map\" and \"my-mode-emacs-map\"."
+  (let ((keyscheme+bindings-pairs (append (list keyscheme bindings) more-keyscheme+bindings-pairs))
+        (name-prefix (if (stringp keyscheme-specifier)
+                         keyscheme-specifier
+                         (getf keyscheme-specifier :name-prefix)))
+        (imported-keyscheme-map (unless (stringp keyscheme-specifier)
+                                  (getf keyscheme-specifier :import))))
+    (unless (stringp keyscheme-specifier)
+      (check-plist keyscheme-specifier :name-prefix :import))
+    (loop :for (keyscheme quoted-bindings . nil) :on keyscheme+bindings-pairs :by #'cddr
           :for bindings = (rest quoted-bindings)
-          :do (check-type (symbol-value name) scheme-name)
+          :do (check-type (symbol-value keyscheme) keyscheme)
           :do (check-type bindings list)
           :do (loop :for (keyspecs bound-value . nil) :on bindings :by #'cddr
                     :do (check-type keyspecs (or keyspecs-type list))
                     :when (quoted-symbol-p bound-value)
-                      :do (assert (typep (second bound-value) (bound-type (symbol-value name))) (bound-value)
-                                  'type-error :datum (second bound-value) :expected-type (bound-type (symbol-value name)))))
+                      :do (assert (typep (second bound-value) (bound-type (symbol-value keyscheme))) (bound-value)
+                                  'type-error :datum (second bound-value) :expected-type (bound-type (symbol-value keyscheme)))))
     `(progn
-       (define-scheme* ,name-prefix ,imported-scheme ,name ,bindings ,@more-name+bindings-pairs))))
+       (define-keyscheme-map* ,name-prefix ,imported-keyscheme-map ,keyscheme ,bindings ,@more-keyscheme+bindings-pairs))))
 
-(declaim (ftype (function (scheme-name scheme) (or keymap null)) get-keymap))
-(defun get-keymap (name scheme)
-  "Return keymap corresponding to NAME in SCHEME.
-If no keymap is associated to NAME in SCHEME, try with NAME's `parents'.
-For instance, if SCHEME has a `scheme:cua' keymap and no `scheme:emacs' keymap,
-this function returns the `scheme:cua' keymap when NAME is `scheme:emacs'.
+(declaim (ftype (function (keyscheme keyscheme-map) (or keymap null)) get-keymap))
+(defun get-keymap (keyscheme keyscheme-map)
+  "Return keymap corresponding to KEYSCHEME in KEYSCHEME-MAP.
+If no keymap is found, try with KEYSCHEME's `parents'.
+For instance, if KEYSCHEME has a `nkeymaps/keyscheme:cua' keymap and no
+`nkeymaps/keyscheme:emacs' keymap, this function returns the
+`nkeymaps/keyscheme:cua' keymap when NAME is `nkeymaps/keyscheme:emacs'.
 Return nil if nothing is found."
-  (or (gethash name scheme)
-      (when (parents name)
-        (some (alexandria:rcurry #'get-keymap scheme) (parents name)))))
+  (or (gethash keyscheme keyscheme-map)
+      (when (parents keyscheme)
+        (some (alexandria:rcurry #'get-keymap keyscheme-map) (parents keyscheme)))))
 
-(declaim (ftype (function (scheme-name keymap &rest (or scheme-name keymap)) scheme) make-scheme))
-(defun make-scheme (name keymap &rest more-name+keymap-pairs)
-  "Return a new scheme associating NAME to KEYMAP.
-With MORE-NAME+KEYMAP-PAIRS, include those names and keymaps as well.  This is
-useful in complement to `define-scheme' to make a scheme with pre-existing
+(declaim (ftype (function (keyscheme keymap &rest (or keyscheme keymap)) keyscheme-map) make-keyscheme-map))
+(defun make-keyscheme-map (keyscheme keymap &rest more-keyscheme+keymap-pairs)
+  "Return a new scheme associating KEYSCHEME to KEYMAP.
+With MORE-KEYSCHEME+KEYMAP-PAIRS, include those names and keymaps as well.  This is
+useful in complement to `define-keyscheme-map' to make a scheme with pre-existing
 keymaps."
-  (let ((scheme (make-hash-table :test #'equal))
-        (name+keymap-pairs (append (list name keymap) more-name+keymap-pairs)))
-    (loop :for (name keymap) :on name+keymap-pairs :by #'cddr
-          :do (setf (gethash name scheme) keymap))
-    scheme))
+  (let ((keyscheme-map (make-hash-table :test #'equal))
+        (keyscheme+keymap-pairs (append (list keyscheme keymap) more-keyscheme+keymap-pairs)))
+    ;; TODO: Use `alex:doplist'.
+    (loop :for (keyscheme keymap) :on keyscheme+keymap-pairs :by #'cddr
+          :do (setf (gethash keyscheme keyscheme-map) keymap))
+    keyscheme-map))

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -1,7 +1,6 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-;; TODO: Rename to keyscheme-tests.lisp.
 ;; TODO: Switch to a better testing framework.
 
 (in-package :nkeymaps/tests)

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -123,7 +123,7 @@
                          nkeymaps:default (list
                                            "M-c" 'hit-me
                                            "C-c" 'hit-me-again)))
-         (new-map (nkeymaps:define-keyscheme-map "imported" (:import imported-map)
+         (new-map (nkeymaps:define-keyscheme-map "imported" `(:import ,imported-map)
                     nkeymaps:default (list
                                       "M-a" 'back
                                       "C-c" 'hit-me-differently))))
@@ -142,7 +142,10 @@
       (assert-eql 'do-not-forward-me (nkeymaps:lookup-key "M-c" imported-keymap))
       (assert-eql 'hit-me (nkeymaps:lookup-key "M-c" new-keymap)))))
 
-;; (prove:subtest "Make scheme with type errors" ; TODO: How do we test macro-expansion-time error?
-;;   (prove:is-error (nkeymaps:define-keyscheme-map
-;;                       nkeymaps:cua (list "C-" 'copy))
-;;                   'type-error))
+(define-test define-key-type-catching ()
+  "Catch bad keyspecs."
+  (let ((form '(lambda ()
+                (nkeymaps:define-keyscheme-map "foo" ()
+                    nkeymaps:cua (list "C-" 'copy)))))
+    (assert-true (nth-value 2 (compile nil form)))
+    (assert-warning 'warning (compile nil form))))

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -57,33 +57,33 @@
 (define-test inheritance ()
   "Test inheritance."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                          nkeymaps:cua (list "C-c" 'copy
-                                             "C-v" 'paste)
+                          nkeymaps:default (list "C-c" 'copy
+                                                 "C-v" 'paste)
                           nkeymaps:emacs (list "M-w" 'copy
                                                "M-y" 'paste)))
-         (cua-keymap (nkeymaps:make-keymap "test-cua-map"))
+         (default-keymap (nkeymaps:make-keymap "test-deefault-map"))
          (emacs-keymap (nkeymaps:make-keymap "test-emacs-map")))
-    (nkeymaps:define-key cua-keymap
+    (nkeymaps:define-key default-keymap
       "C-c" 'copy
       "C-v" 'paste)
     (nkeymaps:define-key emacs-keymap
       "M-w" 'copy
       "M-y" 'paste)
     (assert-equal (nkeymaps:parents (gethash nkeymaps:emacs keyscheme-map))
-                  (list (gethash nkeymaps:cua keyscheme-map)))))
+                  (list (gethash nkeymaps:default keyscheme-map)))))
 
 (define-test get-keymap ()
   "Get keymap."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                          nkeymaps:cua (list "C-c" 'copy
+                          nkeymaps:default (list "C-c" 'copy
                                              "C-v" 'paste)
                           nkeymaps:emacs (list "M-w" 'copy
                                                "M-y" 'paste))))
     (assert-true (nkeymaps:get-keymap nkeymaps:emacs keyscheme-map))
-    (assert-true (nkeymaps:get-keymap nkeymaps:cua keyscheme-map))
-    (assert-false (equal (nkeymaps:get-keymap nkeymaps:cua keyscheme-map)
+    (assert-true (nkeymaps:get-keymap nkeymaps:default keyscheme-map))
+    (assert-false (equal (nkeymaps:get-keymap nkeymaps:default keyscheme-map)
                          (nkeymaps:get-keymap nkeymaps:emacs keyscheme-map)))
-    (assert-equal (nkeymaps:get-keymap nkeymaps:cua keyscheme-map)
+    (assert-equal (nkeymaps:get-keymap nkeymaps:default keyscheme-map)
                   (nkeymaps:get-keymap nkeymaps:vi-normal keyscheme-map))))
 
 (define-test prioritize-scheme-over-parent ()

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -8,37 +8,37 @@
 (define-test make-keyscheme ()
   "Make keyscheme."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                          nkeymaps/keyscheme:cua '("C-c" copy
-                                                   "C-v" paste)))
+                          nkeymaps:cua '("C-c" copy
+                                         "C-v" paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
     (nkeymaps:define-key keymap "C-c" 'copy)
     (nkeymaps:define-key keymap "C-v" 'paste)
     (assert-equality #'fset:equal?
                      (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
-                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map))))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps:cua keyscheme-map))))
     (assert-equal (nkeymaps:name keymap)
-                  (nkeymaps:name (gethash nkeymaps/keyscheme:cua keyscheme-map)))))
+                  (nkeymaps:name (gethash nkeymaps:cua keyscheme-map)))))
 
 (define-test make-keyscheme-map ()
   "Make keyscheme-map with `list'."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                          nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                                       "C-v" 'paste)))
+                          nkeymaps:cua (list "C-c" 'copy
+                                             "C-v" 'paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
     (nkeymaps:define-key keymap
       "C-c" 'copy
       "C-v" 'paste)
     (assert-equality #'fset:equal?
                      (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
-                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map))))))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps:cua keyscheme-map))))))
 
 (define-test make-schsme-with-multiple-names ()
   "Make scheme with multiple names"
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                          nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                                       "C-v" 'paste)
-                          nkeymaps/keyscheme:emacs (list "M-w" 'copy
-                                                         "M-y" 'paste)))
+                          nkeymaps:cua (list "C-c" 'copy
+                                             "C-v" 'paste)
+                          nkeymaps:emacs (list "M-w" 'copy
+                                               "M-y" 'paste)))
          (cua-keymap (nkeymaps:make-keymap "test-cua-map"))
          (emacs-keymap (nkeymaps:make-keymap "test-emacs-map")))
     (nkeymaps:define-key cua-keymap
@@ -49,18 +49,18 @@
       "M-y" 'paste)
     (assert-equality #'fset:equal?
                      (fset:convert 'fset:map (nkeymaps:keymap->map cua-keymap))
-                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map))))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps:cua keyscheme-map))))
     (assert-equality #'fset:equal?
                      (fset:convert 'fset:map (nkeymaps:keymap->map emacs-keymap))
-                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:emacs keyscheme-map))))))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps:emacs keyscheme-map))))))
 
 (define-test inheritance ()
   "Test inheritance."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                          nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                                       "C-v" 'paste)
-                          nkeymaps/keyscheme:emacs (list "M-w" 'copy
-                                                         "M-y" 'paste)))
+                          nkeymaps:cua (list "C-c" 'copy
+                                             "C-v" 'paste)
+                          nkeymaps:emacs (list "M-w" 'copy
+                                               "M-y" 'paste)))
          (cua-keymap (nkeymaps:make-keymap "test-cua-map"))
          (emacs-keymap (nkeymaps:make-keymap "test-emacs-map")))
     (nkeymaps:define-key cua-keymap
@@ -69,37 +69,37 @@
     (nkeymaps:define-key emacs-keymap
       "M-w" 'copy
       "M-y" 'paste)
-    (assert-equal (nkeymaps:parents (gethash nkeymaps/keyscheme:emacs keyscheme-map))
-                  (list (gethash nkeymaps/keyscheme:cua keyscheme-map)))))
+    (assert-equal (nkeymaps:parents (gethash nkeymaps:emacs keyscheme-map))
+                  (list (gethash nkeymaps:cua keyscheme-map)))))
 
 (define-test get-keymap ()
   "Get keymap."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                          nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                                       "C-v" 'paste)
-                          nkeymaps/keyscheme:emacs (list "M-w" 'copy
-                                                         "M-y" 'paste))))
-    (assert-true (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map))
-    (assert-true (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map))
-    (assert-false (equal (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
-                         (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map)))
-    (assert-equal (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
-                  (nkeymaps:get-keymap nkeymaps/keyscheme:vi-normal keyscheme-map))))
+                          nkeymaps:cua (list "C-c" 'copy
+                                             "C-v" 'paste)
+                          nkeymaps:emacs (list "M-w" 'copy
+                                               "M-y" 'paste))))
+    (assert-true (nkeymaps:get-keymap nkeymaps:emacs keyscheme-map))
+    (assert-true (nkeymaps:get-keymap nkeymaps:cua keyscheme-map))
+    (assert-false (equal (nkeymaps:get-keymap nkeymaps:cua keyscheme-map)
+                         (nkeymaps:get-keymap nkeymaps:emacs keyscheme-map)))
+    (assert-equal (nkeymaps:get-keymap nkeymaps:cua keyscheme-map)
+                  (nkeymaps:get-keymap nkeymaps:vi-normal keyscheme-map))))
 
 (define-test prioritize-scheme-over-parent ()
   "Prioritize scheme over parent."
   (let* ((keyscheme-map1 (nkeymaps:define-keyscheme-map "test1"
-                           nkeymaps/keyscheme:cua (list "C-c" 'do-not-hit-me)
-                           nkeymaps/keyscheme:emacs (list "M-w" 'copy)))
+                           nkeymaps:cua (list "C-c" 'do-not-hit-me)
+                           nkeymaps:emacs (list "M-w" 'copy)))
          (keyscheme-map2 (nkeymaps:define-keyscheme-map "test2"
-                           nkeymaps/keyscheme:emacs (list "C-c" 'hit-me))))
+                           nkeymaps:emacs (list "C-c" 'hit-me))))
     (let ((keymaps (mapcar (lambda (scheme)
-                             (nkeymaps:get-keymap nkeymaps/keyscheme:emacs scheme))
+                             (nkeymaps:get-keymap nkeymaps:emacs scheme))
                            (list keyscheme-map1 keyscheme-map2))))
       (assert-eql 'hit-me
                   (nkeymaps:lookup-key "C-c" keymaps)))))
 
 ;; (prove:subtest "Make scheme with type errors" ; TODO: How do we test macro-expansion-time error?
 ;;   (prove:is-error (nkeymaps:define-keyscheme-map
-;;                       nkeymaps/keyscheme:cua (list "C-" 'copy))
+;;                       nkeymaps:cua (list "C-" 'copy))
 ;;                   'type-error))

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -99,6 +99,26 @@
       (assert-eql 'hit-me
                   (nkeymaps:lookup-key "C-c" keymaps)))))
 
+(define-test custom-modifiers ()
+  "Define scheme with custom modifiers."
+  (let* ((+custom+ (make-instance 'nkeymaps:keyscheme
+                                  :name "custom"
+                                  :modifiers (fset:set
+                                              nkeymaps:+control+
+                                              (nkeymaps:define-modifier :string "duper" :shortcut "D"))))
+         (keyscheme-map (nkeymaps:define-keyscheme-map "test"
+                          +custom+ (list
+                                    "D-c" 'hit-me
+                                    "C-c" 'hit-me-again))))
+
+    (let ((keymap (nkeymaps:get-keymap +custom+ keyscheme-map)))
+      (assert-eql 'hit-me
+                  (nkeymaps:lookup-key "D-c" keymap))
+      (assert-eql 'hit-me-again
+                  (nkeymaps:lookup-key "C-c" keymap))
+      (assert-error 'nkeymaps/conditions:bad-modifier
+                    (nkeymaps:lookup-key "M-c" keymap)))))
+
 ;; (prove:subtest "Make scheme with type errors" ; TODO: How do we test macro-expansion-time error?
 ;;   (prove:is-error (nkeymaps:define-keyscheme-map
 ;;                       nkeymaps:cua (list "C-" 'copy))

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -7,7 +7,7 @@
 
 (define-test make-keyscheme ()
   "Make keyscheme."
-  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test" ()
                           nkeymaps:cua '("C-c" copy
                                          "C-v" paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
@@ -21,7 +21,7 @@
 
 (define-test make-keyscheme-map ()
   "Make keyscheme-map with `list'."
-  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test" ()
                           nkeymaps:cua (list "C-c" 'copy
                                              "C-v" 'paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
@@ -34,7 +34,7 @@
 
 (define-test make-schsme-with-multiple-names ()
   "Make scheme with multiple names"
-  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test" ()
                           nkeymaps:cua (list "C-c" 'copy
                                              "C-v" 'paste)
                           nkeymaps:emacs (list "M-w" 'copy
@@ -56,7 +56,7 @@
 
 (define-test inheritance ()
   "Test inheritance."
-  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test" ()
                           nkeymaps:default (list "C-c" 'copy
                                                  "C-v" 'paste)
                           nkeymaps:emacs (list "M-w" 'copy
@@ -74,7 +74,7 @@
 
 (define-test get-keymap ()
   "Get keymap."
-  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test" ()
                           nkeymaps:default (list "C-c" 'copy
                                              "C-v" 'paste)
                           nkeymaps:emacs (list "M-w" 'copy
@@ -88,10 +88,10 @@
 
 (define-test prioritize-scheme-over-parent ()
   "Prioritize scheme over parent."
-  (let* ((keyscheme-map1 (nkeymaps:define-keyscheme-map "test1"
+  (let* ((keyscheme-map1 (nkeymaps:define-keyscheme-map "test1" ()
                            nkeymaps:cua (list "C-c" 'do-not-hit-me)
                            nkeymaps:emacs (list "M-w" 'copy)))
-         (keyscheme-map2 (nkeymaps:define-keyscheme-map "test2"
+         (keyscheme-map2 (nkeymaps:define-keyscheme-map "test2" ()
                            nkeymaps:emacs (list "C-c" 'hit-me))))
     (let ((keymaps (mapcar (lambda (scheme)
                              (nkeymaps:get-keymap nkeymaps:emacs scheme))
@@ -106,7 +106,7 @@
                                   :modifiers (fset:set
                                               nkeymaps:+control+
                                               (nkeymaps:define-modifier :string "duper" :shortcut "D"))))
-         (keyscheme-map (nkeymaps:define-keyscheme-map "test"
+         (keyscheme-map (nkeymaps:define-keyscheme-map "test" ()
                           +custom+ (list
                                     "D-c" 'hit-me
                                     "C-c" 'hit-me-again))))
@@ -118,6 +118,31 @@
                   (nkeymaps:lookup-key "C-c" keymap))
       (assert-error 'nkeymaps/conditions:bad-modifier
                     (nkeymaps:lookup-key "M-c" keymap)))))
+
+(define-test imported-keyscheme-map ()
+  "Define scheme with custom modifiers."
+  (let* ((imported-map (nkeymaps:define-keyscheme-map "imported" ()
+                         nkeymaps:default (list
+                                           "M-c" 'hit-me
+                                           "C-c" 'hit-me-again)))
+         (new-map (nkeymaps:define-keyscheme-map "imported" (:import imported-map)
+                    nkeymaps:default (list
+                                      "M-a" 'back
+                                      "C-c" 'hit-me-differently))))
+
+    (let ((new-keymap (nkeymaps:get-keymap nkeymaps:default new-map))
+          (imported-keymap (nkeymaps:get-keymap nkeymaps:default imported-map)))
+      (assert-eql 'hit-me (nkeymaps:lookup-key "M-c" new-keymap))
+      (assert-eql 'hit-me-differently (nkeymaps:lookup-key "C-c" new-keymap))
+      (assert-eql 'back (nkeymaps:lookup-key "M-a" new-keymap))
+
+      (assert-eql 'hit-me (nkeymaps:lookup-key "M-c" imported-keymap))
+      (assert-eql 'hit-me-again (nkeymaps:lookup-key "C-c" imported-keymap))
+      (assert-false (nkeymaps:lookup-key "M-a" imported-keymap))
+
+      (nkeymaps:define-key imported-keymap "M-c" 'do-not-forward-me)
+      (assert-eql 'do-not-forward-me (nkeymaps:lookup-key "M-c" imported-keymap))
+      (assert-eql 'hit-me (nkeymaps:lookup-key "M-c" new-keymap)))))
 
 ;; (prove:subtest "Make scheme with type errors" ; TODO: How do we test macro-expansion-time error?
 ;;   (prove:is-error (nkeymaps:define-keyscheme-map

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -5,39 +5,40 @@
 
 (in-package :nkeymaps/tests)
 
-(prove:plan nil)
-
-(prove:subtest "Make keyscheme"
+(define-test make-keyscheme ()
+  "Make keyscheme."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
                           nkeymaps/keyscheme:cua '("C-c" copy
                                                    "C-v" paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
     (nkeymaps:define-key keymap "C-c" 'copy)
     (nkeymaps:define-key keymap "C-v" 'paste)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map)))
-              (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
-              :test #'fset:equal?)
-    (prove:is (nkeymaps:name (gethash nkeymaps/keyscheme:cua keyscheme-map))
-              (nkeymaps:name keymap))))
+    (assert-equality #'fset:equal?
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map))))
+    (assert-equal (nkeymaps:name keymap)
+                  (nkeymaps:name (gethash nkeymaps/keyscheme:cua keyscheme-map)))))
 
-(prove:subtest "Make keyscheme-map with `list'"
+(define-test make-keyscheme-map ()
+  "Make keyscheme-map with `list'."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                     nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                        "C-v" 'paste)))
+                          nkeymaps/keyscheme:cua (list "C-c" 'copy
+                                                       "C-v" 'paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
     (nkeymaps:define-key keymap
       "C-c" 'copy
       "C-v" 'paste)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map)))
-              (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
-              :test #'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map))))))
 
-(prove:subtest "Make scheme with multiple names"
+(define-test make-schsme-with-multiple-names ()
+  "Make scheme with multiple names"
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                     nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                      "C-v" 'paste)
-                   nkeymaps/keyscheme:emacs (list "M-w" 'copy
-                                      "M-y" 'paste)))
+                          nkeymaps/keyscheme:cua (list "C-c" 'copy
+                                                       "C-v" 'paste)
+                          nkeymaps/keyscheme:emacs (list "M-w" 'copy
+                                                         "M-y" 'paste)))
          (cua-keymap (nkeymaps:make-keymap "test-cua-map"))
          (emacs-keymap (nkeymaps:make-keymap "test-emacs-map")))
     (nkeymaps:define-key cua-keymap
@@ -46,19 +47,20 @@
     (nkeymaps:define-key emacs-keymap
       "M-w" 'copy
       "M-y" 'paste)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map)))
-              (fset:convert 'fset:map (nkeymaps:keymap->map cua-keymap))
-              :test #'fset:equal?)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:emacs keyscheme-map)))
-              (fset:convert 'fset:map (nkeymaps:keymap->map emacs-keymap))
-              :test #'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:convert 'fset:map (nkeymaps:keymap->map cua-keymap))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map))))
+    (assert-equality #'fset:equal?
+                     (fset:convert 'fset:map (nkeymaps:keymap->map emacs-keymap))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:emacs keyscheme-map))))))
 
-(prove:subtest "Test inheritance"
+(define-test inheritance ()
+  "Test inheritance."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                     nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                      "C-v" 'paste)
-                   nkeymaps/keyscheme:emacs (list "M-w" 'copy
-                                      "M-y" 'paste)))
+                          nkeymaps/keyscheme:cua (list "C-c" 'copy
+                                                       "C-v" 'paste)
+                          nkeymaps/keyscheme:emacs (list "M-w" 'copy
+                                                         "M-y" 'paste)))
          (cua-keymap (nkeymaps:make-keymap "test-cua-map"))
          (emacs-keymap (nkeymaps:make-keymap "test-emacs-map")))
     (nkeymaps:define-key cua-keymap
@@ -67,36 +69,37 @@
     (nkeymaps:define-key emacs-keymap
       "M-w" 'copy
       "M-y" 'paste)
-    (prove:is (list (gethash nkeymaps/keyscheme:cua keyscheme-map))
-              (nkeymaps:parents (gethash nkeymaps/keyscheme:emacs keyscheme-map)))))
+    (assert-equal (nkeymaps:parents (gethash nkeymaps/keyscheme:emacs keyscheme-map))
+                  (list (gethash nkeymaps/keyscheme:cua keyscheme-map)))))
 
-(prove:subtest "Get keymap"
+(define-test get-keymap ()
+  "Get keymap."
   (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
-                   nkeymaps/keyscheme:cua (list "C-c" 'copy
-                                    "C-v" 'paste)
-                   nkeymaps/keyscheme:emacs (list "M-w" 'copy
-                                      "M-y" 'paste))))
-    (prove:ok (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map))
-    (prove:ok (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map))
-    (prove:isnt (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
-                (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map))
-    (prove:is (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
-              (nkeymaps:get-keymap nkeymaps/keyscheme:vi-normal keyscheme-map))))
+                          nkeymaps/keyscheme:cua (list "C-c" 'copy
+                                                       "C-v" 'paste)
+                          nkeymaps/keyscheme:emacs (list "M-w" 'copy
+                                                         "M-y" 'paste))))
+    (assert-true (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map))
+    (assert-true (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map))
+    (assert-false (equal (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
+                         (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map)))
+    (assert-equal (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
+                  (nkeymaps:get-keymap nkeymaps/keyscheme:vi-normal keyscheme-map))))
 
-(prove:subtest "Prioritize scheme over parent."
+(define-test prioritize-scheme-over-parent ()
+  "Prioritize scheme over parent."
   (let* ((keyscheme-map1 (nkeymaps:define-keyscheme-map "test1"
                            nkeymaps/keyscheme:cua (list "C-c" 'do-not-hit-me)
                            nkeymaps/keyscheme:emacs (list "M-w" 'copy)))
          (keyscheme-map2 (nkeymaps:define-keyscheme-map "test2"
                            nkeymaps/keyscheme:emacs (list "C-c" 'hit-me))))
-    (let ((keymaps (mapcar (lambda (scheme) (nkeymaps:get-keymap nkeymaps/keyscheme:emacs scheme))
+    (let ((keymaps (mapcar (lambda (scheme)
+                             (nkeymaps:get-keymap nkeymaps/keyscheme:emacs scheme))
                            (list keyscheme-map1 keyscheme-map2))))
-      (prove:is (nkeymaps:lookup-key "C-c" keymaps)
-                'hit-me))))
+      (assert-eql 'hit-me
+                  (nkeymaps:lookup-key "C-c" keymaps)))))
 
 ;; (prove:subtest "Make scheme with type errors" ; TODO: How do we test macro-expansion-time error?
 ;;   (prove:is-error (nkeymaps:define-keyscheme-map
 ;;                       nkeymaps/keyscheme:cua (list "C-" 'copy))
 ;;                   'type-error))
-
-(prove:finalize)

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -142,7 +142,7 @@
       (assert-eql 'do-not-forward-me (nkeymaps:lookup-key "M-c" imported-keymap))
       (assert-eql 'hit-me (nkeymaps:lookup-key "M-c" new-keymap)))))
 
-(define-test define-key-type-catching ()
+(define-test define-keyscheme-type-catching ()
   "Catch bad keyspecs."
   (let ((form '(lambda ()
                 (nkeymaps:define-keyscheme-map "foo" ()

--- a/tests/keyscheme-tests.lisp
+++ b/tests/keyscheme-tests.lisp
@@ -1,8 +1,6 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-;; TODO: Switch to a better testing framework.
-
 (in-package :nkeymaps/tests)
 
 (define-test make-keyscheme ()

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -4,5 +4,5 @@
 (in-package :cl-user)
 
 (uiop:define-package nkeymaps/tests
-  (:use #:common-lisp)
+  (:use #:common-lisp #:lisp-unit2)
   (:import-from #:nkeymaps))

--- a/tests/scheme-tests.lisp
+++ b/tests/scheme-tests.lisp
@@ -1,40 +1,43 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
+;; TODO: Rename to keyscheme-tests.lisp.
+;; TODO: Switch to a better testing framework.
+
 (in-package :nkeymaps/tests)
 
 (prove:plan nil)
 
-(prove:subtest "Make scheme"
-  (let* ((scheme (nkeymaps:define-scheme "test"
-                   nkeymaps/scheme:cua '("C-c" copy
-                                "C-v" paste)))
+(prove:subtest "Make keyscheme"
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+                          nkeymaps/keyscheme:cua '("C-c" copy
+                                                   "C-v" paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
     (nkeymaps:define-key keymap "C-c" 'copy)
     (nkeymaps:define-key keymap "C-v" 'paste)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/scheme:cua scheme)))
+    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map)))
               (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
               :test #'fset:equal?)
-    (prove:is (nkeymaps:name (gethash nkeymaps/scheme:cua scheme))
+    (prove:is (nkeymaps:name (gethash nkeymaps/keyscheme:cua keyscheme-map))
               (nkeymaps:name keymap))))
 
-(prove:subtest "Make scheme with LIST"
-  (let* ((scheme (nkeymaps:define-scheme "test"
-                     nkeymaps/scheme:cua (list "C-c" 'copy
-                                      "C-v" 'paste)))
+(prove:subtest "Make keyscheme-map with `list'"
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+                     nkeymaps/keyscheme:cua (list "C-c" 'copy
+                                        "C-v" 'paste)))
          (keymap (nkeymaps:make-keymap "test-cua-map")))
     (nkeymaps:define-key keymap
       "C-c" 'copy
       "C-v" 'paste)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/scheme:cua scheme)))
+    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map)))
               (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
               :test #'fset:equal?)))
 
 (prove:subtest "Make scheme with multiple names"
-  (let* ((scheme (nkeymaps:define-scheme "test"
-                     nkeymaps/scheme:cua (list "C-c" 'copy
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+                     nkeymaps/keyscheme:cua (list "C-c" 'copy
                                       "C-v" 'paste)
-                   nkeymaps/scheme:emacs (list "M-w" 'copy
+                   nkeymaps/keyscheme:emacs (list "M-w" 'copy
                                       "M-y" 'paste)))
          (cua-keymap (nkeymaps:make-keymap "test-cua-map"))
          (emacs-keymap (nkeymaps:make-keymap "test-emacs-map")))
@@ -44,18 +47,18 @@
     (nkeymaps:define-key emacs-keymap
       "M-w" 'copy
       "M-y" 'paste)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/scheme:cua scheme)))
+    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:cua keyscheme-map)))
               (fset:convert 'fset:map (nkeymaps:keymap->map cua-keymap))
               :test #'fset:equal?)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/scheme:emacs scheme)))
+    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map (gethash nkeymaps/keyscheme:emacs keyscheme-map)))
               (fset:convert 'fset:map (nkeymaps:keymap->map emacs-keymap))
               :test #'fset:equal?)))
 
 (prove:subtest "Test inheritance"
-  (let* ((scheme (nkeymaps:define-scheme "test"
-                     nkeymaps/scheme:cua (list "C-c" 'copy
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+                     nkeymaps/keyscheme:cua (list "C-c" 'copy
                                       "C-v" 'paste)
-                   nkeymaps/scheme:emacs (list "M-w" 'copy
+                   nkeymaps/keyscheme:emacs (list "M-w" 'copy
                                       "M-y" 'paste)))
          (cua-keymap (nkeymaps:make-keymap "test-cua-map"))
          (emacs-keymap (nkeymaps:make-keymap "test-emacs-map")))
@@ -65,36 +68,36 @@
     (nkeymaps:define-key emacs-keymap
       "M-w" 'copy
       "M-y" 'paste)
-    (prove:is (list (gethash nkeymaps/scheme:cua scheme))
-              (nkeymaps:parents (gethash nkeymaps/scheme:emacs scheme)))))
+    (prove:is (list (gethash nkeymaps/keyscheme:cua keyscheme-map))
+              (nkeymaps:parents (gethash nkeymaps/keyscheme:emacs keyscheme-map)))))
 
 (prove:subtest "Get keymap"
-  (let* ((scheme (nkeymaps:define-scheme "test"
-                   nkeymaps/scheme:cua (list "C-c" 'copy
+  (let* ((keyscheme-map (nkeymaps:define-keyscheme-map "test"
+                   nkeymaps/keyscheme:cua (list "C-c" 'copy
                                     "C-v" 'paste)
-                   nkeymaps/scheme:emacs (list "M-w" 'copy
+                   nkeymaps/keyscheme:emacs (list "M-w" 'copy
                                       "M-y" 'paste))))
-    (prove:ok (nkeymaps:get-keymap nkeymaps/scheme:emacs scheme))
-    (prove:ok (nkeymaps:get-keymap nkeymaps/scheme:cua scheme))
-    (prove:isnt (nkeymaps:get-keymap nkeymaps/scheme:cua scheme)
-                (nkeymaps:get-keymap nkeymaps/scheme:emacs scheme))
-    (prove:is (nkeymaps:get-keymap nkeymaps/scheme:cua scheme)
-              (nkeymaps:get-keymap nkeymaps/scheme:vi-normal scheme))))
+    (prove:ok (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map))
+    (prove:ok (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map))
+    (prove:isnt (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
+                (nkeymaps:get-keymap nkeymaps/keyscheme:emacs keyscheme-map))
+    (prove:is (nkeymaps:get-keymap nkeymaps/keyscheme:cua keyscheme-map)
+              (nkeymaps:get-keymap nkeymaps/keyscheme:vi-normal keyscheme-map))))
 
 (prove:subtest "Prioritize scheme over parent."
-  (let* ((scheme1 (nkeymaps:define-scheme "test1"
-                    nkeymaps/scheme:cua (list "C-c" 'do-not-hit-me)
-                    nkeymaps/scheme:emacs (list "M-w" 'copy)))
-         (scheme2 (nkeymaps:define-scheme "test2"
-                    nkeymaps/scheme:emacs (list "C-c" 'hit-me))))
-    (let ((keymaps (mapcar (lambda (scheme) (nkeymaps:get-keymap nkeymaps/scheme:emacs  scheme))
-                           (list scheme1 scheme2))                   ))
-      (prove:is (nkeymaps:lookup-key  "C-c" keymaps)
+  (let* ((keyscheme-map1 (nkeymaps:define-keyscheme-map "test1"
+                           nkeymaps/keyscheme:cua (list "C-c" 'do-not-hit-me)
+                           nkeymaps/keyscheme:emacs (list "M-w" 'copy)))
+         (keyscheme-map2 (nkeymaps:define-keyscheme-map "test2"
+                           nkeymaps/keyscheme:emacs (list "C-c" 'hit-me))))
+    (let ((keymaps (mapcar (lambda (scheme) (nkeymaps:get-keymap nkeymaps/keyscheme:emacs scheme))
+                           (list keyscheme-map1 keyscheme-map2))))
+      (prove:is (nkeymaps:lookup-key "C-c" keymaps)
                 'hit-me))))
 
 ;; (prove:subtest "Make scheme with type errors" ; TODO: How do we test macro-expansion-time error?
-;;   (prove:is-error (nkeymaps:define-scheme
-;;                       nkeymaps/scheme:cua (list "C-" 'copy))
+;;   (prove:is-error (nkeymaps:define-keyscheme-map
+;;                       nkeymaps/keyscheme:cua (list "C-" 'copy))
 ;;                   'type-error))
 
 (prove:finalize)

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -6,8 +6,6 @@
 (defun empty-keymap (&rest parents)
   (apply #'nkeymaps:make-keymap "anonymous" parents))
 
-;; TODO: Test with CCL.
-
 (define-test make-key ()
   "Make key."
   (let* ((key (nkeymaps:make-key :code 38 :value "a" :modifiers '("C")))
@@ -31,6 +29,14 @@
                 (nkeymaps:make-key :value "a" :modifiers '("Z")))
   (assert-error 'nkeymaps:make-key-required-arg
                 (nkeymaps:make-key :status :pressed)))
+
+(define-test define-key-type-catching ()
+  "Catch bad keyspecs."
+  (let ((form '(lambda ()
+                (let ((keymap (nkeymaps:make-keymap "anonymous")))
+                  (nkeymaps:define-key keymap "z---" 'open-file)))))
+    (assert-true (nth-value 2 (compile nil form)))
+    (assert-warning 'warning (compile nil form))))
 
 (define-test make-same-key ()
   "Make same key."

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -3,133 +3,143 @@
 
 (in-package :nkeymaps/tests)
 
-(prove:plan nil)
-
 (defun empty-keymap (&rest parents)
   (apply #'nkeymaps:make-keymap "anonymous" parents))
 
-(prove:subtest "Make key"
+;; TODO: Test with CCL.
+
+(define-test make-key ()
+  "Make key."
   (let* ((key (nkeymaps:make-key :code 38 :value "a" :modifiers '("C")))
          (mod (first (fset:convert 'list (nkeymaps:key-modifiers key)))))
-    (prove:is (nkeymaps:key-code key)
-              38)
-    (prove:is (nkeymaps:key-value key)
-              "a")
-    (prove:is mod "C" :test #'nkeymaps:modifier=)
-    (prove:is mod "control" :test #'nkeymaps:modifier=)
-    (prove:is mod nkeymaps:+control+ :test #'nkeymaps:modifier=)
-    (prove:isnt mod "" :test #'nkeymaps:modifier=)
-    (prove:isnt mod "M" :test #'nkeymaps:modifier=)
-    (prove:isnt mod "meta" :test #'nkeymaps:modifier=)))
+    (assert-equal 38
+                  (nkeymaps:key-code key))
+    (assert-equal "a"
+                  (nkeymaps:key-value key))
+    (assert-equality #'nkeymaps:modifier= "C" mod)
+    (assert-equality #'nkeymaps:modifier= "control" mod)
+    (assert-equality #'nkeymaps:modifier= nkeymaps:+control+ mod)
+    (assert-false (nkeymaps:modifier= "" mod))
+    (assert-false (nkeymaps:modifier= "M" mod))
+    (assert-false (nkeymaps:modifier= "meta" mod))))
 
-(prove:subtest "Make bad key"
-  (prove:is-error (nkeymaps:make-key :value "a" :status :dummy)
-                  'type-error)
-  (prove:is-error (nkeymaps:make-key :value "a" :modifiers '("Z"))
-                  'nkeymaps:bad-modifier)
-  (prove:is-error (nkeymaps:make-key :status :pressed)
-                  'nkeymaps:make-key-required-arg))
+(define-test make-bad-key ()
+  "Make bad key."
+  (assert-error 'type-error
+                (nkeymaps:make-key :value "a" :status :dummy))
+  (assert-error 'nkeymaps:bad-modifier
+                (nkeymaps:make-key :value "a" :modifiers '("Z")))
+  (assert-error 'nkeymaps:make-key-required-arg
+                (nkeymaps:make-key :status :pressed)))
 
-(prove:subtest "Make same key"
-  (prove:is (nkeymaps:make-key :value "a" :modifiers '("C" "M"))
-            (nkeymaps:make-key :value "a" :modifiers '("M" "C"))
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps:make-key :value "a" :modifiers '("C"))
-            (nkeymaps:make-key :value "a" :modifiers '("control"))
-            :test #'nkeymaps:key=))
+(define-test make-same-key ()
+  "Make same key."
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "a" :modifiers '("M" "C"))
+                   (nkeymaps:make-key :value "a" :modifiers '("C" "M")))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "a" :modifiers '("control"))
+                   (nkeymaps:make-key :value "a" :modifiers '("C"))))
 
-(prove:subtest "Make key with duplicate modifiers (trigger warning)"
-  (prove:is (nkeymaps:make-key :value "a" :modifiers '("C" "control"))
-            (nkeymaps:make-key :value "a" :modifiers '("C"))
-            :test #'nkeymaps:key=))
+(define-test make-key-with-duplicate-modifiers ()
+  "Make key with duplicate modifiers (trigger warning)."
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "a" :modifiers '("C"))
+                   (nkeymaps:make-key :value "a" :modifiers '("C" "control"))))
 
-(prove:subtest "Make different key"
-  (prove:isnt (nkeymaps:make-key :value "a")
-              (nkeymaps:make-key :value "A")
-              :test #'nkeymaps:key=))
+(define-test make-different-key ()
+  "Make different key."
+  (assert-false (nkeymaps:key= (nkeymaps:make-key :value "a")
+                               (nkeymaps:make-key :value "A"))))
 
-(prove:subtest "Keyspec->key"
-  (prove:is (nkeymaps::keyspec->key "a")
-            (nkeymaps:make-key :value "a")
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "C-a")
-            (nkeymaps:make-key :value "a" :modifiers '("C"))
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "C-M-a")
-            (nkeymaps:make-key :value "a" :modifiers '("C" "M"))
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "C--")
-            (nkeymaps:make-key :value "-" :modifiers '("C"))
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "C-M--")
-            (nkeymaps:make-key :value "-" :modifiers '("C" "M"))
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "C-#")
-            (nkeymaps:make-key :value "#" :modifiers '("C"))
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "#")
-            (nkeymaps:make-key :value "#")
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "-")
-            (nkeymaps:make-key :value "-")
-            :test #'nkeymaps:key=)
-  (prove:is (nkeymaps::keyspec->key "C-#10")
-            (nkeymaps:make-key :code 10 :modifiers '("C"))
-            :test #'nkeymaps:key=)
-  (prove:is-error (nkeymaps::keyspec->key "")
-                  'nkeymaps:empty-keyspec)
-  (prove:is-error (nkeymaps::keyspec->key "C-")
-                  'nkeymaps:empty-value)
-  (prove:is-error (nkeymaps::keyspec->key "C---")
-                  'nkeymaps:empty-modifiers))
+(define-test keyspec->key ()
+  "Keyspec->key."
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "a")
+                   (nkeymaps::keyspec->key "a"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "a" :modifiers '("C"))
+                   (nkeymaps::keyspec->key "C-a"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "a" :modifiers '("C" "M"))
+                   (nkeymaps::keyspec->key "C-M-a"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "-" :modifiers '("C"))
+                   (nkeymaps::keyspec->key "C--"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "-" :modifiers '("C" "M"))
+                   (nkeymaps::keyspec->key "C-M--"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "#" :modifiers '("C"))
+                   (nkeymaps::keyspec->key "C-#"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "#")
+                   (nkeymaps::keyspec->key "#"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :value "-")
+                   (nkeymaps::keyspec->key "-"))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key :code 10 :modifiers '("C"))
+                   (nkeymaps::keyspec->key "C-#10"))
+  (assert-error 'nkeymaps:empty-keyspec
+                (nkeymaps::keyspec->key ""))
+  (assert-error 'nkeymaps:empty-value
+                (nkeymaps::keyspec->key "C-"))
+  (assert-error 'nkeymaps:empty-modifiers
+                (nkeymaps::keyspec->key "C---")))
 
 (defun binding= (keys1 keys2)
   (not (position nil (mapcar #'nkeymaps:key= keys1 keys2))))
 
-(prove:subtest "Keyspecs->keys"
-  (prove:is (nkeymaps::keyspecs->keys "C-x C-f")
-            (list (nkeymaps:make-key :value "x" :modifiers '("C"))
-                  (nkeymaps:make-key :value "f" :modifiers '("C")))
-            :test #'binding=)
-  (prove:is (nkeymaps::keyspecs->keys "  C-x   C-f  ")
-            (list (nkeymaps:make-key :value "x" :modifiers '("C"))
-                  (nkeymaps:make-key :value "f" :modifiers '("C")))
-            :test #'binding=))
+(define-test keyspecs->keys ()
+  "Keyspecs->keys."
+  (assert-equality #'binding=
+                   (list (nkeymaps:make-key :value "x" :modifiers '("C"))
+                         (nkeymaps:make-key :value "f" :modifiers '("C")))
+                   (nkeymaps::keyspecs->keys "C-x C-f"))
+  (assert-equality #'binding=
+                   (list (nkeymaps:make-key :value "x" :modifiers '("C"))
+                         (nkeymaps:make-key :value "f" :modifiers '("C")))
+                   (nkeymaps::keyspecs->keys "  C-x   C-f  ")))
 
-(prove:subtest "define-key & lookup-key"
+(define-test define-key-lookup-key ()
+  "define-key & lookup-key."
   (let ((keymap (empty-keymap)))
     (nkeymaps:define-key keymap "C-x" 'foo)
-    (prove:is (nkeymaps:lookup-key "C-x" keymap)
-              'foo)
+    (assert-eql 'foo
+                (nkeymaps:lookup-key "C-x" keymap))
     (nkeymaps:define-key keymap "C-x" 'foo2)
-    (prove:is (nkeymaps:lookup-key "C-x" keymap)
-              'foo2)
+    (assert-eql 'foo2
+                (nkeymaps:lookup-key "C-x" keymap))
     (nkeymaps:define-key keymap "C-c C-f" 'bar)
-    (prove:is (nkeymaps:lookup-key "C-c C-f" keymap)
-              'bar)
+    (assert-eql 'bar
+                (nkeymaps:lookup-key "C-c C-f" keymap))
     (nkeymaps:define-key keymap "C-c C-h" 'bar2)
-    (prove:is (nkeymaps:lookup-key "C-c C-h" keymap)
-              'bar2)))
+    (assert-eql 'bar2
+                (nkeymaps:lookup-key "C-c C-h" keymap))))
 
-(prove:subtest "define-key type error"
+(define-test define-key-type-error ()
+  "define-key type error."
   (let ((keymap (empty-keymap)))
     (setf (nkeymaps:bound-type keymap) '(or nkeymaps::keymap function))
-    (prove:is (nkeymaps:define-key keymap "C-x" #'format)
-              keymap)
-    (prove:is-error (nkeymaps:define-key keymap "C-c" 'append)
-                    'type-error)))
+    (assert-equal (nkeymaps:define-key keymap "C-x" #'format)
+                  keymap)
+    (assert-error 'type-error
+                  (nkeymaps:define-key keymap "C-c" 'append))))
 
-(prove:subtest "define-key & multiple bindings"
+(define-test define-key-multiple-bindings ()
+  "define-key & multiple bindings."
   (let ((keymap (empty-keymap)))
     (nkeymaps:define-key keymap
       "C-x" 'foo
       "C-c" 'bar)
-    (prove:is (nkeymaps:lookup-key "C-x" keymap)
-              'foo)
-    (prove:is (nkeymaps:lookup-key "C-c" keymap)
-              'bar)))
+    (assert-eql 'foo
+                (nkeymaps:lookup-key "C-x" keymap))
+    (assert-eql 'bar
+                (nkeymaps:lookup-key "C-c" keymap))))
 
-(prove:subtest "define-key & lookup-key with parents"
+(define-test define-key-lookup-key-parents ()
+  "define-key & lookup-key with parents."
   (let* ((parent1 (empty-keymap))
          (parent2 (empty-keymap))
          (keymap (empty-keymap parent1 parent2)))
@@ -137,80 +147,86 @@
     (nkeymaps:define-key parent1 "a" 'parent1-a)
     (nkeymaps:define-key parent2 "x" 'parent2-x)
     (nkeymaps:define-key parent2 "b" 'parent2-b)
-    (prove:is (nkeymaps:lookup-key "x" keymap)
-              'parent1-x)
-    (prove:is (nkeymaps:lookup-key "a" keymap)
-              'parent1-a)
-    (prove:is (nkeymaps:lookup-key "b" keymap)
-              'parent2-b)))
+    (assert-eql 'parent1-x
+                (nkeymaps:lookup-key "x" keymap))
+    (assert-eql 'parent1-a
+                (nkeymaps:lookup-key "a" keymap))
+    (assert-eql 'parent2-b
+                (nkeymaps:lookup-key "b" keymap))))
 
-(prove:subtest "define-key & lookup-key with prefix keymap"
+(define-test define-key-lookup-key-prefix-keymap ()
+  "define-key & lookup-key with prefix keymap."
   (let ((keymap (empty-keymap))
         (prefix (empty-keymap)))
     (nkeymaps:define-key keymap "C-c" prefix)
     (nkeymaps:define-key prefix "x" 'prefix-sym)
-    (prove:is (nkeymaps:lookup-key "C-c x" keymap)
-              'prefix-sym)))
+    (assert-eql 'prefix-sym
+                (nkeymaps:lookup-key "C-c x" keymap))))
 
-(prove:subtest "define-key & lookup-key with cycle"
+(define-test define-key-lookup-key-cycle ()
+  "define-key & lookup-key with cycle."
   (let ((keymap (empty-keymap))
         (parent1 (empty-keymap))
         (parent2 (empty-keymap)))
     (push parent1 (nkeymaps:parents keymap))
     (push parent2 (nkeymaps:parents parent1))
     (push keymap (nkeymaps:parents parent2))
-    (prove:is (nkeymaps:lookup-key "x" keymap)
-              nil)))
+    (assert-warning 'nkeymaps:cycle
+                    (nkeymaps:lookup-key "x" keymap))))
 
-(prove:subtest "Translator"
+(define-test translator ()
+  "Translator."
   (let ((keymap (empty-keymap)))
     (nkeymaps:define-key keymap "A b" 'foo)
-    (prove:is (nkeymaps:lookup-key "shift-a shift-B" keymap)
-              'foo)
+    (assert-eql 'foo
+                (nkeymaps:lookup-key "shift-a shift-B" keymap))
     (nkeymaps:define-key keymap "c" 'bar)
-    (prove:is (nkeymaps:lookup-key "shift-c" keymap)
-              'bar)
+    (assert-eql 'bar
+                (nkeymaps:lookup-key "shift-c" keymap))
     (nkeymaps:define-key keymap "C-x c" 'baz)
-    (prove:is (nkeymaps:lookup-key "C-x C-c" keymap)
-              'baz)
+    (assert-eql 'baz
+                (nkeymaps:lookup-key "C-x C-c" keymap))
     (nkeymaps:define-key keymap "C-c F" 'qux)
-    (prove:is (nkeymaps:lookup-key "C-shift-c C-shift-F" keymap)
-              'qux)
+    (assert-eql 'qux
+                (nkeymaps:lookup-key "C-shift-c C-shift-F" keymap))
     (nkeymaps:define-key keymap "1" 'quux)
-    (prove:is (nkeymaps:lookup-key "shift-1" keymap)
-              'quux)
+    (assert-eql 'quux
+                (nkeymaps:lookup-key "shift-1" keymap))
     (nkeymaps:define-key keymap "return" 'ret)
-    (prove:is (nkeymaps:lookup-key "shift-return" keymap)
-              'ret)))
+    (assert-eql 'ret
+                (nkeymaps:lookup-key "shift-return" keymap))))
 
-(prove:subtest "Translator: Ensure other keymaps have priority over translations"
+(define-test translator-priority ()
+  "Translator: Ensure other keymaps have priority over translations."
   (let ((keymap (empty-keymap))
         (keymap2 (empty-keymap)))
     (nkeymaps:define-key keymap "g g" 'prefix-g)
     (nkeymaps:define-key keymap2 "G" 'up-g)
-    (prove:is (nkeymaps:lookup-key "s-G" (list keymap keymap2))
-              'up-g)))
+    (assert-eql 'up-g
+                (nkeymaps:lookup-key "s-G" (list keymap keymap2)))))
 
-(prove:subtest "keys->keyspecs"
-  (prove:is (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :code 10 :value "a")))
-            "#10")
-  (prove:is (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a")
-                                          (nkeymaps:make-key :value "b")))
-            "a b")
-  (prove:is (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C"))))
-            "C-a")
-  (prove:is (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C" "M"))))
-            "C-M-a")
-  (prove:is (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("M" "C"))))
-            "C-M-a")
-  (prove:is (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C" "M"))
-                                          (nkeymaps:make-key :value "x" :modifiers '("super" "hyper"))))
-            "C-M-a H-S-x")
+(define-test keys->keyspecs ()
+  "keys->keyspecs."
+  (assert-equal "#10"
+                (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :code 10 :value "a"))))
+  (assert-equal "a b"
+                (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a")
+                                               (nkeymaps:make-key :value "b"))))
+  (assert-equal "C-a"
+                (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C")))))
+  (assert-equal "C-M-a"
+                (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C" "M")))))
+  (assert-equal "C-M-a"
+                (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("M" "C")))))
+  (assert-equal "C-M-a H-S-x"
+                (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C" "M"))
+                                               (nkeymaps:make-key :value "x" :modifiers '("super" "hyper")))))
   (let ((nkeymaps:*print-shortcut* nil))
-    (prove:is (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C"))))
-              "control-a")))
+    (assert-equal "control-a"
+                  (nkeymaps:keys->keyspecs (list (nkeymaps:make-key :value "a" :modifiers '("C")))))))
 
-(prove:subtest "keymap->map"
+(define-test keymap->map ()
+  "keymap->map."
   (let ((keymap (empty-keymap))
         (keymap2 (empty-keymap)))
     (nkeymaps:define-key keymap "a" 'foo-a)
@@ -218,46 +234,48 @@
     (nkeymaps:define-key keymap "k" keymap2)
     (nkeymaps:define-key keymap2 "a" 'bar-a)
     (nkeymaps:define-key keymap2 "c" 'bar-c)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
-              (fset:map ("a" 'foo-a)
-                        ("b" 'foo-b)
-                        ("k a" 'bar-a)
-                        ("k c" 'bar-c))
-              :test #'fset:equal?)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map keymap keymap2))
-              (fset:map ("a" 'foo-a)
-                        ("b" 'foo-b)
-                        ("c" 'bar-c)
-                        ("k a" 'bar-a)
-                        ("k c" 'bar-c))
-              :test #'fset:equal?)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map keymap2 keymap))
-              (fset:map ("a" 'bar-a)
-                        ("b" 'foo-b)
-                        ("c" 'bar-c)
-                        ("k a" 'bar-a)
-                        ("k c" 'bar-c))
-              :test #'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:map ("a" 'foo-a)
+                               ("b" 'foo-b)
+                               ("k a" 'bar-a)
+                               ("k c" 'bar-c))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap)))
+    (assert-equality #'fset:equal?
+                     (fset:map ("a" 'foo-a)
+                               ("b" 'foo-b)
+                               ("c" 'bar-c)
+                               ("k a" 'bar-a)
+                               ("k c" 'bar-c))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap keymap2)))
+    (assert-equality #'fset:equal?
+                     (fset:map ("a" 'bar-a)
+                               ("b" 'foo-b)
+                               ("c" 'bar-c)
+                               ("k a" 'bar-a)
+                               ("k c" 'bar-c))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap2 keymap)))))
 
-(prove:subtest "keymap->map with cycles" ; TODO: Can we check warnings?
+(define-test keymap->map-cycles ()      ; TODO: Can we check warnings?
+  "keymap->map with cycles."
   (let ((keymap (empty-keymap))
         (keymap2 (empty-keymap)))
     (nkeymaps:define-key keymap "k" keymap2)
     (nkeymaps:define-key keymap2 "a" keymap)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
-              (fset:empty-map)
-              :test #'fset:equal?))
+    (assert-equality #'fset:equal?
+                     (fset:empty-map)
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap))))
   (let ((keymap (empty-keymap))
         (keymap2 (empty-keymap))
         (keymap3 (empty-keymap)))
     (nkeymaps:define-key keymap "k" keymap2)
     (nkeymaps:define-key keymap2 "a" keymap3)
     (nkeymaps:define-key keymap3 "b" keymap)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map keymap))
-              (fset:empty-map)
-              :test #'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:empty-map)
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap)))))
 
-(prove:subtest "keymap-with-parents->map"
+(define-test keymap-with-parents->map ()
+  "keymap-with-parents->map."
   (let* ((grand-parent (empty-keymap))
          (parent1 (empty-keymap))
          (parent2 (empty-keymap grand-parent))
@@ -266,53 +284,55 @@
     (nkeymaps:define-key parent1 "b" 'bar-b)
     (nkeymaps:define-key parent2 "c" 'qux-c)
     (nkeymaps:define-key grand-parent "d" 'quux-d)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap))
-              (fset:map ("a" 'foo-a)
-                        ("b" 'bar-b)
-                        ("c" 'qux-c)
-                        ("d" 'quux-d))
-              :test #'fset:equal?)
+    (assert-equality #'fset:equal?
+                     (fset:map ("a" 'foo-a)
+                               ("b" 'bar-b)
+                               ("c" 'qux-c)
+                               ("d" 'quux-d))
+                     (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap)))
     (nkeymaps:define-key parent2 "d" 'qux-d)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap))
-              (fset:map ("a" 'foo-a)
-                        ("b" 'bar-b)
-                        ("c" 'qux-c)
-                        ("d" 'qux-d))
-              :test #'fset:equal?)
+    (assert-equality #'fset:equal?
+                     (fset:map ("a" 'foo-a)
+                               ("b" 'bar-b)
+                               ("c" 'qux-c)
+                               ("d" 'qux-d))
+                     (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap)))
     (nkeymaps:define-key parent1 "c" 'bar-c)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap))
-              (fset:map ("a" 'foo-a)
-                        ("b" 'bar-b)
-                        ("c" 'bar-c)
-                        ("d" 'qux-d))
-              :test #'fset:equal?)
+    (assert-equality #'fset:equal?
+                     (fset:map ("a" 'foo-a)
+                               ("b" 'bar-b)
+                               ("c" 'bar-c)
+                               ("d" 'qux-d))
+                     (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap)))
     (nkeymaps:define-key parent1 "b" 'foo-b)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap))
-              (fset:map ("a" 'foo-a)
-                        ("b" 'foo-b)
-                        ("c" 'bar-c)
-                        ("d" 'qux-d))
-              :test #'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:map ("a" 'foo-a)
+                               ("b" 'foo-b)
+                               ("c" 'bar-c)
+                               ("d" 'qux-d))
+                     (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap)))))
 
-(prove:subtest "keymap-with-parents->map with cycles" ; TODO: Can we check warnings?
+(define-test keymap-with-parents->map-cycles () ; TODO: Can we check warnings?
+  "keymap-with-parents->map with cycles."
   (let ((keymap1 (empty-keymap))
         (keymap2 (empty-keymap)))
     (push keymap1 (nkeymaps:parents keymap2))
     (push keymap2 (nkeymaps:parents keymap1))
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap1))
-              (fset:empty-map)
-              :test #'fset:equal?))
+    (assert-equality #'fset:equal?
+                     (fset:empty-map)
+                     (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap1))))
   (let ((keymap1 (empty-keymap))
         (keymap2 (empty-keymap))
         (keymap3 (empty-keymap)))
     (push keymap1 (nkeymaps:parents keymap2))
     (push keymap2 (nkeymaps:parents keymap3))
     (push keymap3 (nkeymaps:parents keymap1))
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap1))
-              (fset:empty-map)
-              :test #'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:empty-map)
+                     (fset:convert 'fset:map (nkeymaps:keymap-with-parents->map keymap1)))))
 
-(prove:subtest "compose-keymaps"
+(define-test compose-keymaps ()
+  "compose-keymaps."
   (let* ((parent1 (empty-keymap))
          (keymap1 (nkeymaps:make-keymap "1" parent1))
          (parent2 (empty-keymap))
@@ -325,133 +345,134 @@
     (nkeymaps:define-key keymap3 "c" 'qux-c)
     (nkeymaps:define-key keymap3 "d" 'qux-d)
     (let ((composition (nkeymaps:compose keymap1 keymap2 keymap3)))
-      (prove:is (nkeymaps:name composition)
-                "1+2+anonymous")
-      (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map composition))
-                (fset:map
-                 ("a" 'foo-a)
-                 ("b" 'foo-b)
-                 ("c" 'bar-c)
-                 ("d" 'qux-d))
-                :test #'fset:equal?)
-      (prove:is (nkeymaps:parents composition)
-                (list parent1 parent2)))))
+      (assert-equal "1+2+anonymous"
+                    (nkeymaps:name composition))
+      (assert-equality #'fset:equal?
+                       (fset:map
+                        ("a" 'foo-a)
+                        ("b" 'foo-b)
+                        ("c" 'bar-c)
+                        ("d" 'qux-d))
+                       (fset:convert 'fset:map (nkeymaps:keymap->map composition)))
+      (assert-equal (list parent1 parent2)
+                    (nkeymaps:parents composition)))))
 
-(prove:subtest "compose: Altering source does not impact composition"
+(define-test compose ()
+  "compose: Altering source does not impact composition."
   (let* ((keymap1 (nkeymaps:make-keymap "1"))
          (keymap2 nil))
     (nkeymaps:define-key keymap1 "a" 'foo-a)
     (setf keymap2 (nkeymaps:compose keymap1))
     (nkeymaps:define-key keymap1 "a" 'foo-a-alt)
     (nkeymaps:define-key keymap1 "b" 'new-foo)
-    (prove:is (fset:convert 'fset:map (nkeymaps:keymap->map keymap2))
-              (fset:map
-               ("a" 'foo-a))
-              :test #'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:map
+                      ("a" 'foo-a))
+                     (fset:convert 'fset:map (nkeymaps:keymap->map keymap2)))))
 
-(prove:subtest "binding-keys"
+(define-test binding-keys ()
+  "binding-keys."
   (let* ((keymap1 (empty-keymap))
          (keymap2 (empty-keymap))
          (keymap3 (empty-keymap keymap1)))
     (nkeymaps:define-key keymap1 "a" 'foo-a)
     (nkeymaps:define-key keymap1 "b" 'foo-b)
     (nkeymaps:define-key keymap1 "C-c a" 'foo-a)
-
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'foo-a keymap1))
-              `(("C-c a" "a")
-                (("C-c a" ,keymap1)
-                 ("a" ,keymap1))))
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'foo-b keymap1))
-              `(("b")
-                (("b" ,keymap1))))
-    (prove:is (nkeymaps:binding-keys 'missing keymap1)
-              nil)
+    (assert-equal (values '("C-c a" "a")
+                          `(("C-c a" ,keymap1)
+                            ("a" ,keymap1)))
+                  (nkeymaps:binding-keys 'foo-a keymap1))
+    (assert-equal (values '("b")
+                          `(("b" ,keymap1)))
+                  (nkeymaps:binding-keys 'foo-b keymap1))
+    (assert-false (nkeymaps:binding-keys 'missing keymap1))
     (nkeymaps:define-key keymap2 "a" 'foo-a)
     (nkeymaps:define-key keymap2 "c" 'foo-a)
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'foo-a (list keymap1 keymap2)))
-              `(("C-c a" "a" "c")
-                (("C-c a" ,keymap1)
-                 ("a" ,keymap1)
-                 ("c" ,keymap2))))
+    (assert-equal (values '("C-c a" "a" "c")
+                          `(("C-c a" ,keymap1)
+                            ("a" ,keymap1)
+                            ("c" ,keymap2)))
+                  (nkeymaps:binding-keys 'foo-a (list keymap1 keymap2)))
 
     ;; Ordering:
     (nkeymaps:define-key keymap1 "E" 'bar-e)
     (nkeymaps:define-key keymap1 "F" 'bar-f)
     (nkeymaps:define-key keymap2 "D" 'bar-e)
     (nkeymaps:define-key keymap2 "G" 'bar-f)
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'bar-e (list keymap1 keymap2)))
-              `(("E" "D")
-                (("E" ,keymap1)
-                 ("D" ,keymap2))))
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'bar-e (list keymap2 keymap1)))
-              `(("D" "E")
-                (("D" ,keymap2)
-                 ("E" ,keymap1))))
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'bar-f (list keymap1 keymap2)))
-              `(("F" "G")
-                (("F" ,keymap1)
-                 ("G" ,keymap2))))
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'bar-f (list keymap2 keymap1)))
-              `(("G" "F")
-                (("G" ,keymap2)
-                 ("F" ,keymap1))))
+    (assert-equal (values '("E" "D")
+                          `(("E" ,keymap1)
+                            ("D" ,keymap2)))
+                  (nkeymaps:binding-keys 'bar-e (list keymap1 keymap2)))
+    (assert-equal (values '("D" "E")
+                          `(("D" ,keymap2)
+                            ("E" ,keymap1)))
+                  (nkeymaps:binding-keys 'bar-e (list keymap2 keymap1)))
+    (assert-equal (values '("F" "G")
+                          `(("F" ,keymap1)
+                            ("G" ,keymap2)))
+                  (nkeymaps:binding-keys 'bar-f (list keymap1 keymap2)))
+    (assert-equal (values '("G" "F")
+                          `(("G" ,keymap2)
+                            ("F" ,keymap1)))
+                  (nkeymaps:binding-keys 'bar-f (list keymap2 keymap1)))
 
     ;; Inheritance:
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'foo-a keymap3))
-              `(("C-c a" "a")
-                (("C-c a" ,keymap1)
-                 ("a" ,keymap1))))
+    (assert-equal (values '("C-c a" "a")
+                          `(("C-c a" ,keymap1)
+                            ("a" ,keymap1)))
+                  (nkeymaps:binding-keys 'foo-a keymap3))
 
     ;; Shadowing:
     (nkeymaps:define-key keymap3 "a" 'shadowed-a)
-    (prove:is (multiple-value-list (nkeymaps:binding-keys 'foo-a keymap3))
-              `(("C-c a")
-                (("C-c a" ,keymap1))))))
+    (assert-equal (values '("C-c a")
+                          `(("C-c a" ,keymap1)))
+                  (nkeymaps:binding-keys 'foo-a keymap3))))
 
-(prove:subtest "undefine"
+(define-test undefine ()
+  "undefine."
   (let* ((keymap (empty-keymap)))
     (nkeymaps:define-key keymap "a" 'foo-a)
     (nkeymaps:define-key keymap "a" nil)
-    (prove:is (nkeymaps::entries keymap)
-              (fset:empty-map)
-              :test 'fset:equal?)
+    (assert-equality #'fset:equal?
+                     (fset:empty-map)
+                     (nkeymaps::entries keymap))
     (nkeymaps:define-key keymap "C-c b" 'foo-b)
     (nkeymaps:define-key keymap "C-c b" nil)
-    (prove:is (nkeymaps::entries keymap)
-              (fset:empty-map)
-              :test 'fset:equal?)))
+    (assert-equality #'fset:equal?
+                     (fset:empty-map)
+                     (nkeymaps::entries keymap))))
 
-(prove:subtest "remap"
+(define-test remap ()
+  "remap."
   (let* ((keymap (empty-keymap))
          (keymap2 (empty-keymap)))
     (nkeymaps:define-key keymap "a" 'foo-a)
     (nkeymaps:define-key keymap '(:remap foo-a) 'foo-b)
-    (prove:is (nkeymaps:lookup-key "a" keymap)
-              'foo-b)
+    (assert-eql 'foo-b
+                (nkeymaps:lookup-key "a" keymap))
     (nkeymaps:define-key keymap2 "b" 'bar-1)
     (nkeymaps:define-key keymap `(:remap bar-1 ,keymap2) 'bar-2)
-    (prove:is (nkeymaps:lookup-key "b" keymap)
-              'bar-2)))
+    (assert-eql 'bar-2
+                (nkeymaps:lookup-key "b" keymap))))
 
-(prove:subtest "retrieve translated key"
+(define-test retrieve-translated-key ()
+  "retrieve translated key."
   (let* ((keymap (empty-keymap)))
     (nkeymaps:define-key keymap "a" 'foo-a)
     (multiple-value-bind (hit km key)
         (nkeymaps:lookup-key "s-A" keymap)
-      (prove:is hit 'foo-a)
-      (prove:is km keymap)
-      (prove:is (nkeymaps:keys->keyspecs key) "a"))))
+      (assert-eql 'foo-a hit)
+      (assert-eql keymap km)
+      (assert-equal "a" (nkeymaps:keys->keyspecs key)))))
 
-(prove:subtest "Don't shadow a prefix keymap"
+(define-test do-not-shadow-prefix-keymap ()
+  "Don't shadow a prefix keymap."
   (let* ((parent (empty-keymap))
          (keymap (empty-keymap parent)))
     (nkeymaps:define-key parent "C-x" 'parent-x)
     (nkeymaps:define-key keymap "C-x C-f" 'keymap-x)
-    (prove:is (nkeymaps:lookup-key "C-x C-f" keymap)
-              'keymap-x)
-    (prove:is (nkeymaps:lookup-key "C-x C-f" parent)
-              nil)
-    (prove:is (nkeymaps:lookup-key "C-x" parent)
-              'parent-x)))
-
-(prove:finalize)
+    (assert-eql 'keymap-x
+                (nkeymaps:lookup-key "C-x C-f" keymap))
+    (assert-false (nkeymaps:lookup-key "C-x C-f" parent))
+    (assert-eql 'parent-x
+                (nkeymaps:lookup-key "C-x" parent))))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -62,37 +62,37 @@
   "Keyspec->key."
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "a")
-                   (nkeymaps::keyspec->key "a"))
+                   (nkeymaps/core::keyspec->key "a"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "a" :modifiers '("C"))
-                   (nkeymaps::keyspec->key "C-a"))
+                   (nkeymaps/core::keyspec->key "C-a"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "a" :modifiers '("C" "M"))
-                   (nkeymaps::keyspec->key "C-M-a"))
+                   (nkeymaps/core::keyspec->key "C-M-a"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "-" :modifiers '("C"))
-                   (nkeymaps::keyspec->key "C--"))
+                   (nkeymaps/core::keyspec->key "C--"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "-" :modifiers '("C" "M"))
-                   (nkeymaps::keyspec->key "C-M--"))
+                   (nkeymaps/core::keyspec->key "C-M--"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "#" :modifiers '("C"))
-                   (nkeymaps::keyspec->key "C-#"))
+                   (nkeymaps/core::keyspec->key "C-#"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "#")
-                   (nkeymaps::keyspec->key "#"))
+                   (nkeymaps/core::keyspec->key "#"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :value "-")
-                   (nkeymaps::keyspec->key "-"))
+                   (nkeymaps/core::keyspec->key "-"))
   (assert-equality #'nkeymaps:key=
                    (nkeymaps:make-key :code 10 :modifiers '("C"))
-                   (nkeymaps::keyspec->key "C-#10"))
+                   (nkeymaps/core::keyspec->key "C-#10"))
   (assert-error 'nkeymaps:empty-keyspec
-                (nkeymaps::keyspec->key ""))
+                (nkeymaps/core::keyspec->key "" t))
   (assert-error 'nkeymaps:empty-value
-                (nkeymaps::keyspec->key "C-"))
+                (nkeymaps/core::keyspec->key "C-" t))
   (assert-error 'nkeymaps:empty-modifiers
-                (nkeymaps::keyspec->key "C---")))
+                (nkeymaps/core::keyspec->key "C---" t)))
 
 (defun binding= (keys1 keys2)
   (not (position nil (mapcar #'nkeymaps:key= keys1 keys2))))
@@ -102,11 +102,11 @@
   (assert-equality #'binding=
                    (list (nkeymaps:make-key :value "x" :modifiers '("C"))
                          (nkeymaps:make-key :value "f" :modifiers '("C")))
-                   (nkeymaps::keyspecs->keys "C-x C-f"))
+                   (nkeymaps/core::keyspecs->keys "C-x C-f"))
   (assert-equality #'binding=
                    (list (nkeymaps:make-key :value "x" :modifiers '("C"))
                          (nkeymaps:make-key :value "f" :modifiers '("C")))
-                   (nkeymaps::keyspecs->keys "  C-x   C-f  ")))
+                   (nkeymaps/core::keyspecs->keys "  C-x   C-f  ")))
 
 (define-test define-key-lookup-key ()
   "define-key & lookup-key."

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -441,12 +441,12 @@
     (nkeymaps:define-key keymap "a" nil)
     (assert-equality #'fset:equal?
                      (fset:empty-map)
-                     (nkeymaps::entries keymap))
+                     (nkeymaps/core::entries keymap))
     (nkeymaps:define-key keymap "C-c b" 'foo-b)
     (nkeymaps:define-key keymap "C-c b" nil)
     (assert-equality #'fset:equal?
                      (fset:empty-map)
-                     (nkeymaps::entries keymap))))
+                     (nkeymaps/core::entries keymap))))
 
 (define-test remap ()
   "remap."

--- a/translators.lisp
+++ b/translators.lisp
@@ -1,0 +1,91 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :nkeymaps/translator)
+
+(declaim (ftype (function (string) string) toggle-case))
+(defun toggle-case (string)
+  "Return the input with reversed case if it has only one character."
+  (if (= 1 (length string))
+      (let ((down (string-downcase string)))
+        (if (string= down string)
+            (string-upcase string)
+            down))
+      string))
+
+(defun translate-remove-shift-toggle-case (keys)
+  "With shift, keys without shift and with their key value case reversed:
+'shift-a shift-B' -> 'A b'."
+  (let ((shift? (find +shift+ keys :key #'key-modifiers :test #'fset:find)))
+    (when shift?
+      (mapcar (lambda (key)
+                (copy-key key :modifiers (fset:less (key-modifiers key) +shift+)
+                              :value (toggle-case (key-value key))))
+              keys))))
+
+(defun translate-remove-shift (keys)
+  "With shift, keys without shift: 'shift-a' -> 'a'."
+  (let ((shift? (find +shift+ keys :key #'key-modifiers :test #'fset:find)))
+    (when shift?
+      (mapcar (lambda (key)
+                (copy-key key :modifiers (fset:less (key-modifiers key) +shift+)))
+              keys))))
+
+(defun translate-remove-but-first-control (keys)
+  "With control, keys without control except for the first key:
+'C-x C-c' -> 'C-x c'."
+  (let ((control? (find +control+ (rest keys) :key #'key-modifiers :test #'fset:find)))
+    (when control?
+      (cons (first keys)
+            (mapcar (lambda (key)
+                      (copy-key key :modifiers (fset:less (key-modifiers key) +control+)))
+                    (rest keys))))))
+
+(defun translate-remove-shift-but-first-control (keys)
+  "With control and shift, keys without control except for the first key and
+without shift everywhere: 'C-shift-C C-shift-f' -> 'C-C f. "
+  (let ((shift? (find +shift+ keys :key #'key-modifiers :test #'fset:find))
+        (control? (find +control+ (rest keys) :key #'key-modifiers :test #'fset:find)))
+    (when (and control? shift?)
+               (cons (copy-key (first keys)
+                               :modifiers (fset:less (key-modifiers (first keys)) +shift+))
+                     (mapcar (lambda (key)
+                               (copy-key key :modifiers (fset:set-difference (key-modifiers key)
+                                                                             (fset:set +control+ +shift+))))
+                             (rest keys))))))
+
+(defun translate-remove-shift-but-first-control-toggle-case (keys)
+  "With control and shift, keys without control except for the first key and
+without shift everywhere: 'C-shift-C C-shift-f' -> 'C-c F. "
+  (let ((control? (find +control+ (rest keys) :key #'key-modifiers :test #'fset:find))
+        (shift? (find +shift+ keys :key #'key-modifiers :test #'fset:find)))
+    (when (and control? shift?)
+               (cons (copy-key (first keys)
+                               :value (toggle-case (key-value (first keys)))
+                               :modifiers (fset:less (key-modifiers (first keys)) +shift+))
+                     (mapcar (lambda (key)
+                               (copy-key key
+                                         :value (toggle-case (key-value key))
+                                         :modifiers (fset:set-difference (key-modifiers key)
+                                                                         (fset:set +control+ +shift+))))
+                             (rest keys))))))
+
+(defun translate-shift-control-combinations (keys)
+  "Return the successive translations of
+- `translate-remove-shift',
+- `translate-remove-shift-toggle-case',
+- `translate-remove-but-first-control',
+- `translate-remove-shift-but-first-control',
+- `translate-remove-shift-but-first-control-toggle-case'.
+
+We first remove shift before toggle the case because we want 's-A' to match an
+'A' binding before matching 'a'."
+  (delete nil
+          (mapcar (lambda (translator) (funcall translator keys))
+                  (list #'translate-remove-shift
+                        #'translate-remove-shift-toggle-case
+                        #'translate-remove-but-first-control
+                        #'translate-remove-shift-but-first-control
+                        #'translate-remove-shift-but-first-control-toggle-case))))
+
+(setf nkeymaps/core:*translator* #'translate-shift-control-combinations)

--- a/types.lisp
+++ b/types.lisp
@@ -1,29 +1,29 @@
 ;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
 ;;;; SPDX-License-Identifier: BSD-3-Clause
 
-(in-package :nkeymaps)
+(uiop:define-package nkeymaps/types
+  (:use #:common-lisp)
+  (:export #:list-of)
+  (:documentation "Package for types.
+It's useful to have a separate package because some types may need to generate
+functions for the `satisfies' type condition."))
+(in-package :nkeymaps/types)
 
 ;; trivial-types:proper-list doesn't check its element type.
 
-(defun list-of-type-p (list typep)
-  "Return non-ni if LIST contains only elements of the given TYPEP predicate."
+(defun list-of-p (list type)
+  "Return non-nil if LIST contains only elements of the given TYPE."
   (and (listp list)
-       (every (lambda (x) (typep x typep)) list)))
+       (every (lambda (x) (typep x type)) list)))
 
-(defmacro define-list-type (type &optional name)
-  "Define type `list-of-TYPEs'.
-If type is not a simple symbol, NAME will be used to define `list-of-NAMEs'.
-Example:
-  (define-list-type 'string)"
-  (let* ((name (string-upcase (string (or name (eval type)))))
-         (predicate (intern (format nil "LIST-OF-~aS-P" name))))
-    `(progn
-       (defun ,predicate (list)
-         (list-of-type-p list ,type))
-       (deftype ,(intern (format nil "LIST-OF-~aS" name)) ()
-         '(satisfies ,predicate)))))
-
-(define-list-type 'string)
-(define-list-type 'key)
-(define-list-type 'keymap)
-(define-list-type 'scheme-name)
+(deftype list-of (type)
+  "The empty list of a proper list of TYPE elements.
+Unlike `(cons TYPE *)', it checks all the elements.
+`(cons TYPE *)' does not accept the empty list."
+  (let ((predicate-name (intern (uiop:strcat "LIST-OF-" (symbol-name type) "-P")
+                                (find-package :nkeymaps/types))))
+    (unless (fboundp predicate-name)
+      (setf (fdefinition predicate-name)
+            (lambda (object)
+              (list-of-p object type))))
+    `(and list (satisfies ,predicate-name))))


### PR DESCRIPTION
This is a pretty big overhaul of the library.  Except from the README:

```org
- Renamed =scheme-name= to =keyscheme= and =scheme= to =keyscheme-map=.
  It's more consistent and intuitive.  The previous naming was really confusing.
- All warnings have now their own conditions, see the =nkeymaps/conditions= package.
- =define-keyscheme-map= has a different syntax, it's now
  #+begin_src lisp
    (define-keyscheme-map "NAME-PREFIX" (:import OPTIONAL-KEYSCHEME-MAP-TO-IMPORT)
      KEYSCHEME BINDINGS...)
  #+end_src
- The predefined =keyscheme=s are now accessible from the =nkeymaps= package.
- New =default= =keyscheme= which is the new parent of other keyschemes
  (including =cua=), instead of =cua=.
- =*modifier-list*= is no longer exported.  Instead, both =keyscheme= and
  =keymap= have a =modifiers= slot for the modifiers they accept.
- Switched testing framework from =Prove= to =Lisp-Unit2=.
- Removed the =cl-str= dependency.
```

@jmercouris @aadcg @aartaka What do you think?
I'll also open a pull request for Nyxt to prepare for the 1.0.0 update.