### PR TITLE
Extend keyspec styles (alternative proposal)

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -35,6 +35,11 @@
    #:*translator*
 
    #:*print-shortcut*
+   #:*modifier-printer*
+   #:print-modifier-cua
+   #:print-modifier-emacs
+   #:print-modifier-default
+
    #:keys->keyspecs
 
    #:keymap->map


### PR DESCRIPTION
This is a draft that follows a strategy proposed in #9 to close issue #4.

I consider this strategy a bad idea because running the snippet below rightfully raises an error - `"Ctrl"` is a string that is used simply for printing, so it's not possible to generate a `key` from it.

```lisp
(let ((keymap (nkeymaps:make-keymap "keymap")))
  (nkeymaps:define-key keymap
    "C-M-s-S-c C-M-s-S-d" 'foo-emacs
    "control-meta-shift-super-e control-meta-shift-super-f" 'foo-no-shortcuts)

  (setf *modifier-printer* #'print-modifier-cua)
  (print (first (nkeymaps:binding-keys 'foo-emacs keymap)))
  (print (first (nkeymaps:binding-keys 'foo-no-shortcuts keymap))))
```

P.S. - sorry for the compilation warnings. They're benign nonetheless.