### PR TITLE
Extend keyspec styles (supersedes PR #9)

### DIFF
--- a/keymap.lisp
+++ b/keymap.lisp
@@ -7,7 +7,8 @@
 
 (defstruct modifier
   (string "" :type string)
-  (shortcut "" :type string))
+  (shortcut "" :type string)
+  (system-name "" :type string))
 
 (declaim (ftype (function ((or string modifier) (or string modifier)) boolean) modifier=))
 (defun modifier= (string-or-modifier1 string-or-modifier2)
@@ -17,7 +18,8 @@
     (error 'bad-modifier :message "At least one of the arguments must be a modifier."))
   (flet ((match-modifier (modifier string)
            (or (string= (modifier-string modifier) string)
-               (string= (modifier-shortcut modifier) string))))
+               (string= (modifier-shortcut modifier) string)
+               (string= (modifier-system-name modifier) string))))
     (cond
       ((stringp string-or-modifier1)
        (match-modifier string-or-modifier2 string-or-modifier1))
@@ -27,7 +29,9 @@
        (or (string= (modifier-string string-or-modifier1)
                     (modifier-string string-or-modifier2))
            (string= (modifier-shortcut string-or-modifier1)
-                    (modifier-shortcut string-or-modifier2)))))))
+                    (modifier-shortcut string-or-modifier2))
+           (string= (modifier-system-name string-or-modifier1)
+                    (modifier-system-name string-or-modifier2)))))))
 
 (defmethod fset:compare ((x modifier) (y modifier))
   "Modifier sets need this comparison function to be ordered, so that (\"C\"
@@ -39,11 +43,11 @@
 `make-key' and `define-key' raise an error when setting a modifier that is not
 in this list.")
 
-(defun define-modifier (&rest args &key string shortcut)
+(defun define-modifier (&rest args &key string shortcut system-name)
   "Return a new modifier.
 It is registered globally and can be used from any new keymap, unless the keymap
 filters out the modifier in its `modifiers' slot."
-  (declare (ignore string shortcut))
+  (declare (ignore string shortcut system-name))
   (let ((result (apply #'make-modifier args)))
     (setf *modifier-list* (delete result *modifier-list*
                                   :test #'modifier=))
@@ -508,7 +512,13 @@ And so on if the binding is still not found."
     (values result matching-keymap matching-key)))
 
 (defparameter *print-shortcut* t
-  "Whether to print the short form of the modifiers.")
+  "Define how modifiers are represented in keyspecs.
+
+Accepted values:
+t, follows the string representation dictated by `modifier-shortcut';
+nil, follows the string representation dictated by `modifier-string';
+\"cua\", follows the string representation dictated by `modifier-system-name'.
+else, follows the string representation dictated by `modifier-shortcut'.")
 
 (defun string-join (strings separator &key end)
   "Adapted from `serapeum:string-join'."
@@ -533,9 +543,14 @@ The status is not encoded in the keyspec, but this may change in the future."
                    (format nil "#~a" (key-code key))))
         (modifiers (fset:reduce (lambda (&rest mods) (string-join mods "-"))
                                 (key-modifiers key)
-                                :key (if *print-shortcut*
-                                         #'modifier-shortcut
-                                         #'modifier-string))))
+                                :key (cond ((null *print-shortcut*)
+                                            #'modifier-string)
+                                           ((and (typep *print-shortcut* 'boolean)
+                                                 *print-shortcut*)
+                                            #'modifier-shortcut)
+                                           ((string-equal *print-shortcut* "cua")
+                                            #'modifier-system-name)
+                                           (t #'modifier-shortcut)))))
     (the (values keyspecs-type &optional)
          (uiop:strcat (if (uiop:emptyp modifiers) "" (uiop:strcat modifiers "-"))
                       value))))

--- a/modifiers.lisp
+++ b/modifiers.lisp
@@ -3,13 +3,23 @@
 
 (in-package :nkeymaps/modifier)
 
-(defparameter +control+ (define-modifier :string "control" :shortcut "C")
+(defparameter +control+
+  (define-modifier :string "control" :shortcut "C"
+    :system-name #+darwin "control" #-darwin "Ctrl")
   "The key modifier commonly known as 'control'.")
-(defparameter +meta+ (define-modifier :string "meta" :shortcut "M")
+(defparameter +meta+
+  (define-modifier :string "meta" :shortcut "M"
+    :system-name #+darwin "option" #-darwin "Alt")
   "The key modifier commonly known as 'alt', 'option' or 'meta'.")
-(defparameter +shift+ (define-modifier :string "shift" :shortcut "s")
+(defparameter +shift+
+  (define-modifier :string "shift" :shortcut "s"
+    :system-name #+darwin "shift" #-darwin "Shift")
   "The key modifier commonly known as 'shift'.")
-(defparameter +super+ (define-modifier :string "super" :shortcut "S")
+(defparameter +super+
+  (define-modifier :string "super" :shortcut "S"
+    :system-name #+darwin "command" #+win32 "Win" #+linux "Super")
   "The key modifier commonly known as 'windows', 'command' or 'super'.")
-(defparameter +hyper+ (define-modifier :string "hyper" :shortcut "H")
+(defparameter +hyper+
+  (define-modifier :string "hyper" :shortcut "H"
+    :system-name "Hyper")
   "The key modifier commonly known as 'hyper'.")

--- a/package.lisp
+++ b/package.lisp
@@ -158,10 +158,12 @@ New modifiers can be defined with `nkeymaps:define-modifier'.
 
 Some globals can be tweaked to customize the library to your needs:
 
-- `nkeymaps:*translator*': The function to infer the right binding when
-  the exact binding hits nothing.
-- `nkeymaps:*print-shortcut*': Print modifiers using their short form instead of the
-  full name, e.g. \"C\" instead of \"control\"."))
+- `nkeymaps:*translator*': The function to infer the right binding when the
+  exact binding hits nothing.
+- `nkeymaps:*print-shortcut*': Defines how modifiers are represented in keyspecs.
+  Possible values are `nil', `t' and `\"cua\"'.
+  E.g. `nkeymaps/modifier:+control+' may be printed as \"control\", \"C\", or
+  \"Ctrl\", respectively for the aforementioned values."))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria :nkeymaps/core)

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -6,3 +6,10 @@
 (uiop:define-package :nkeymaps/tests
   (:use :common-lisp :lisp-unit2)
   (:import-from :nkeymaps))
+
+(in-package :nkeymaps/tests)
+
+(defun cua-modifiers (body-fn)
+  "A context that locally binds `nkeymaps:*print-shortcut*' to \"cua\"."
+  (let ((nkeymaps:*print-shortcut* "cua"))
+    (funcall body-fn)))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -483,3 +483,41 @@
     (assert-false (nkeymaps:lookup-key "C-x C-f" parent))
     (assert-eql 'parent-x
                 (nkeymaps:lookup-key "C-x" parent))))
+
+(define-test cua-modifiers (:contexts 'cua-modifiers)
+  (let* ((key (nkeymaps:make-key :code 38 :value "a" :modifiers '("C")))
+         (mod (first (fset:convert 'list (nkeymaps:key-modifiers key)))))
+    (assert-equality #'nkeymaps:modifier= #+darwin "control" #-darwin "Ctrl" mod)
+    (assert-equality #'nkeymaps:modifier= "control" mod)
+    (assert-equality #'nkeymaps:modifier= "C" mod)
+    (assert-equality #'nkeymaps:modifier= nkeymaps:+control+ mod)
+    (assert-false (nkeymaps:modifier= "bogus" mod)))
+  (assert-equality #'nkeymaps:key=
+                   (nkeymaps:make-key
+                    :value "a"
+                    :modifiers '(#+darwin "control" #-darwin "Ctrl"
+                                 #+darwin "option" #-darwin "Alt"
+                                 #+darwin "shift" #-darwin "Shift"
+                                 #+darwin "command" #+win32 "Win" #+linux "Super"))
+                   (nkeymaps/core::keyspec->key "Ctrl-Alt-Shift-Super-a"))
+  (assert-equality #'binding=
+                   (list (nkeymaps:make-key
+                          :value "x"
+                          :modifiers '(#+darwin "control" #-darwin "Ctrl"
+                                       #+darwin "option" #-darwin "Alt"
+                                       #+darwin "shift" #-darwin "Shift"
+                                       #+darwin "command" #+win32 "Win" #+linux "Super"))
+                         (nkeymaps:make-key
+                          :value "f"
+                          :modifiers '(#+darwin "control" #-darwin "Ctrl"
+                                       #+darwin "option" #-darwin "Alt"
+                                       #+darwin "shift" #-darwin "Shift"
+                                       #+darwin "command" #+win32 "Win" #+linux "Super")))
+                   (nkeymaps/core::keyspecs->keys
+                    "Ctrl-Alt-Shift-Super-x Ctrl-Alt-Shift-Super-f"))
+  (assert-equal #+darwin "control-a"
+                #-darwin "Ctrl-a"
+                (nkeymaps:keys->keyspecs (list (nkeymaps:make-key
+                                                :value "a"
+                                                :modifiers '(#+darwin "control"
+                                                             #-darwin "Ctrl"))))))


### PR DESCRIPTION
This PR follows the strategy started in #9 while maintaining full backwards compatibility. 

I'll have a second look tomorrow and will notify when it'll be ready for review.