### PR TITLE
Keys are not equal when they have different codes and no value.

### DIFF
--- a/keymap.lisp
+++ b/keymap.lisp
@@ -71,8 +71,10 @@ specify a key-code binding."
   (and (or (and (not (zerop (key-code key1)))
                 (= (key-code key1)
                    (key-code key2)))
-           (string= (key-value key1)
-                    (key-value key2)))
+           (and
+            (not (uiop:emptyp (key-value key1)))
+            (string= (key-value key1)
+                     (key-value key2))))
        (fset:equal? (key-modifiers key1)
                     (key-modifiers key2))
        (eq (key-status key1)


### PR DESCRIPTION
Fixes #21.

Rather trivial, or am I missing something?